### PR TITLE
feat : 댓글 CRUD 간단하게 구현, 댓글 입력창 구현

### DIFF
--- a/src/main/java/site/soloforest/soloforest/boundedContext/comment/controller/CommentController.java
+++ b/src/main/java/site/soloforest/soloforest/boundedContext/comment/controller/CommentController.java
@@ -5,6 +5,7 @@ import java.security.Principal;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -77,7 +78,7 @@ public class CommentController {
 
 	// 댓글 삭제 메서드
 	// @PreAuthorize("isAuthenticated()") // 로그인한 사용자만보임
-	@GetMapping("/delete/{id}")
+	@DeleteMapping("/{id}")
 	public String delete(Principal principal, @PathVariable("id") Long id) {
 		Comment comment = this.commentService.getComment(id);
 		if (!comment.getWriter().getUsername().equals(principal.getName())) {

--- a/src/main/java/site/soloforest/soloforest/boundedContext/comment/controller/CommentController.java
+++ b/src/main/java/site/soloforest/soloforest/boundedContext/comment/controller/CommentController.java
@@ -1,11 +1,15 @@
 package site.soloforest.soloforest.boundedContext.comment.controller;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.security.Principal;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.server.ResponseStatusException;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
@@ -23,12 +27,12 @@ public class CommentController {
 
 	private final CommentService commentService;
 
-	private static final Logger logger = LoggerFactory.getLogger(CommentController.class);
-
+	// 디버깅시 활용
+	// private static final Logger logger = LoggerFactory.getLogger(CommentController.class);
+	// 	logger.info("showComment 메서드 호출");
 
 	@GetMapping("")
 	public String showComment(CommentForm commentForm) {
-		logger.info("showComment 메서드 호출");
 		return "comment/comment";
 	}
 
@@ -40,12 +44,48 @@ public class CommentController {
 		private String content;
 	}
 
+	// @PreAuthorize("isAuthenticated()")
+	// user의 Username 가져와서 작성자 정보도 업로드 수정
 	@PostMapping("/create")
-	public String create(@Valid CommentController.CommentForm commentForm) {
-		logger.info("create 메서드 호출");
+	public String create(@Valid CommentForm commentForm) {
 		Comment comment= commentService.create(commentForm.getContent());
-		logger.info("댓글 생성: {}", comment);
 		return "redirect:/main";
+	}
+
+	// @PreAuthorize("isAuthenticated()")
+	@GetMapping("/modify/{id}") 	// 댓글id
+	public String showModify(CommentForm commentForm, @PathVariable("id") Long id, Principal principal) {
+		Comment comment = this.commentService.getComment(id);
+		if (!comment.getWriter().getUsername().equals(principal.getName())) { // 댓글 작성한 회원정보와 일치 여부 확인
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "수정권한이 없습니다");
+		}
+		commentForm.setContent(comment.getContent());
+		return "comment/comment";// 댓글 폼 html
+	}
+
+	// @PreAuthorize("isAuthenticated()")
+	@PostMapping("/modify/{id}") 	// 댓글 id
+	public String modify(@Valid CommentForm commentForm, @PathVariable("id") Long id, Principal principal) {
+		Comment comment = commentService.getComment(id);
+
+		if(!comment.getWriter().getUsername().equals(principal.getName()))
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "수정권한이 없습니다");
+
+		commentService.modify(comment, commentForm.getContent());
+		return "redirect:/main";
+	}
+
+	// 댓글 삭제 메서드
+	// @PreAuthorize("isAuthenticated()") // 로그인한 사용자만보임
+	@GetMapping("/delete/{id}")
+	public String delete(Principal principal, @PathVariable("id") Long id) {
+		Comment comment = this.commentService.getComment(id);
+		if (!comment.getWriter().getUsername().equals(principal.getName())) {
+			// 댓글 작성한 회원정보와 일치 여부 확인
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "삭제권한이 없습니다");
+		}
+		commentService.delete(comment);
+		return "comment/comment";
 	}
 
 }

--- a/src/main/java/site/soloforest/soloforest/boundedContext/comment/controller/CommentController.java
+++ b/src/main/java/site/soloforest/soloforest/boundedContext/comment/controller/CommentController.java
@@ -2,19 +2,43 @@ package site.soloforest.soloforest.boundedContext.comment.controller;
 
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import site.soloforest.soloforest.boundedContext.comment.service.CommentService;
 
 @Controller
 @RequiredArgsConstructor
 @RequestMapping("/comment")
 public class CommentController {
 
+	private final CommentService commentService;
+
 	@GetMapping("")
 	public String showComment() {
 		return "comment/comment";
+	}
+
+	@AllArgsConstructor
+	@Getter
+	public static class CreateCommentForm {
+		@NotBlank(message = "내용은 필수로 입력해야 합니다.")
+		private final String content;
+	}
+
+	@PostMapping("/create")
+	@ResponseBody
+	public String create(@Valid CreateCommentForm createCommentForm) {
+
+		commentService.create(createCommentForm.getContent());
+
+		return "1234";
 	}
 
 }

--- a/src/main/java/site/soloforest/soloforest/boundedContext/comment/controller/CommentController.java
+++ b/src/main/java/site/soloforest/soloforest/boundedContext/comment/controller/CommentController.java
@@ -1,16 +1,19 @@
 package site.soloforest.soloforest.boundedContext.comment.controller;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseBody;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import site.soloforest.soloforest.boundedContext.comment.entity.Comment;
 import site.soloforest.soloforest.boundedContext.comment.service.CommentService;
 
 @Controller
@@ -20,25 +23,29 @@ public class CommentController {
 
 	private final CommentService commentService;
 
+	private static final Logger logger = LoggerFactory.getLogger(CommentController.class);
+
+
 	@GetMapping("")
-	public String showComment() {
+	public String showComment(CommentForm commentForm) {
+		logger.info("showComment 메서드 호출");
 		return "comment/comment";
 	}
 
 	@AllArgsConstructor
 	@Getter
-	public static class CreateCommentForm {
+	@Setter
+	public static class CommentForm {
 		@NotBlank(message = "내용은 필수로 입력해야 합니다.")
-		private final String content;
+		private String content;
 	}
 
 	@PostMapping("/create")
-	@ResponseBody
-	public String create(@Valid CreateCommentForm createCommentForm) {
-
-		commentService.create(createCommentForm.getContent());
-
-		return "1234";
+	public String create(@Valid CommentController.CommentForm commentForm) {
+		logger.info("create 메서드 호출");
+		Comment comment= commentService.create(commentForm.getContent());
+		logger.info("댓글 생성: {}", comment);
+		return "redirect:/main";
 	}
 
 }

--- a/src/main/java/site/soloforest/soloforest/boundedContext/comment/controller/CommentController.java
+++ b/src/main/java/site/soloforest/soloforest/boundedContext/comment/controller/CommentController.java
@@ -1,0 +1,20 @@
+package site.soloforest.soloforest.boundedContext.comment.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import lombok.RequiredArgsConstructor;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/comment")
+public class CommentController {
+
+	@GetMapping("")
+	public String showComment() {
+		return "comment/comment";
+	}
+
+}

--- a/src/main/java/site/soloforest/soloforest/boundedContext/comment/entity/Comment.java
+++ b/src/main/java/site/soloforest/soloforest/boundedContext/comment/entity/Comment.java
@@ -30,7 +30,7 @@ import site.soloforest.soloforest.boundedContext.notification.entity.Notificatio
 
 @Entity
 @Getter
-@Builder
+@Builder(toBuilder = true)
 @EntityListeners(AuditingEntityListener.class)
 @AllArgsConstructor
 @NoArgsConstructor

--- a/src/main/java/site/soloforest/soloforest/boundedContext/comment/repository/CommentRepository.java
+++ b/src/main/java/site/soloforest/soloforest/boundedContext/comment/repository/CommentRepository.java
@@ -5,7 +5,7 @@ import org.springframework.stereotype.Repository;
 
 import site.soloforest.soloforest.boundedContext.comment.entity.Comment;
 
-@Repository
+
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 	Comment findByContent(String content);
 }

--- a/src/main/java/site/soloforest/soloforest/boundedContext/comment/repository/CommentRepository.java
+++ b/src/main/java/site/soloforest/soloforest/boundedContext/comment/repository/CommentRepository.java
@@ -1,0 +1,11 @@
+package site.soloforest.soloforest.boundedContext.comment.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import site.soloforest.soloforest.boundedContext.comment.entity.Comment;
+
+@Repository
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+	Comment findByContent(String content);
+}

--- a/src/main/java/site/soloforest/soloforest/boundedContext/comment/service/CommentService.java
+++ b/src/main/java/site/soloforest/soloforest/boundedContext/comment/service/CommentService.java
@@ -1,0 +1,36 @@
+package site.soloforest.soloforest.boundedContext.comment.service;
+
+import java.security.Principal;
+
+import org.springframework.stereotype.Service;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.RequiredArgsConstructor;
+import site.soloforest.soloforest.boundedContext.account.entity.Account;
+import site.soloforest.soloforest.boundedContext.comment.controller.CommentController;
+import site.soloforest.soloforest.boundedContext.comment.entity.Comment;
+import site.soloforest.soloforest.boundedContext.comment.repository.CommentRepository;
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+
+	private final CommentRepository commentRepository;
+
+	public Comment create(String content) {
+		Comment newComment = Comment.builder()
+			.content(content)
+//			.article(article)
+//			.writer(account)
+			.build();
+
+		commentRepository.save(newComment);
+
+		return newComment;
+	}
+
+	public Comment getComment(String content) {
+		 return commentRepository.findByContent(content);
+	}
+
+}

--- a/src/main/java/site/soloforest/soloforest/boundedContext/comment/service/CommentService.java
+++ b/src/main/java/site/soloforest/soloforest/boundedContext/comment/service/CommentService.java
@@ -1,14 +1,9 @@
 package site.soloforest.soloforest.boundedContext.comment.service;
 
-import java.security.Principal;
-
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
-import site.soloforest.soloforest.boundedContext.account.entity.Account;
-import site.soloforest.soloforest.boundedContext.comment.controller.CommentController;
 import site.soloforest.soloforest.boundedContext.comment.entity.Comment;
 import site.soloforest.soloforest.boundedContext.comment.repository.CommentRepository;
 
@@ -19,6 +14,7 @@ public class CommentService {
 
 	private final CommentRepository commentRepository;
 
+	// 작성자 정보를 위해 로그인한 회원 정보 받아서 넣기는 아직 안함
 	@Transactional
 	public Comment create(String content) {
 		Comment newComment = Comment.builder()
@@ -30,8 +26,29 @@ public class CommentService {
 		return newComment;
 	}
 
+	// 테스트용
 	public Comment getComment(String content) {
 		 return commentRepository.findByContent(content);
 	}
 
+	public Comment getComment(Long commentId) {
+		return commentRepository.findById(commentId).get();
+	}
+
+	// 수정, 아직 대댓글, 비밀댓글 고려 안함
+	@Transactional
+	public Comment modify(Comment comment, String content) {
+		Comment mComment = comment.toBuilder()
+			.content(content)
+			.build();
+		commentRepository.save(mComment);
+
+		return mComment;
+	}
+
+	// 삭제
+	@Transactional
+	public void delete(Comment comment) {
+		commentRepository.delete(comment);
+	}
 }

--- a/src/main/java/site/soloforest/soloforest/boundedContext/comment/service/CommentService.java
+++ b/src/main/java/site/soloforest/soloforest/boundedContext/comment/service/CommentService.java
@@ -3,6 +3,7 @@ package site.soloforest.soloforest.boundedContext.comment.service;
 import java.security.Principal;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
@@ -13,15 +14,15 @@ import site.soloforest.soloforest.boundedContext.comment.repository.CommentRepos
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class CommentService {
 
 	private final CommentRepository commentRepository;
 
+	@Transactional
 	public Comment create(String content) {
 		Comment newComment = Comment.builder()
 			.content(content)
-//			.article(article)
-//			.writer(account)
 			.build();
 
 		commentRepository.save(newComment);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,9 +11,9 @@ spring:
     url: jdbc:mariadb://127.0.0.1:3306/soloforest__dev?useUnicode=true&characterEncoding=utf8&autoReconnect=true&serverTimezone=Asia/Seoul
     username: lldj
     password: lldj123414
-jpa:
-  hibernate:
-    ddl-auto: create
+  jpa:
+    hibernate:
+      ddl-auto: create
   properties:
     hibernate:
       show_sql: true
@@ -22,6 +22,6 @@ jpa:
 logging:
   level:
     root: INFO
-    com.ll.gramgram: DEBUG  #패키지명
+    com.ll.soloForest: DEBUG  #패키지명
     org.hibernate.orm.jdbc.bind: TRACE
     org.hibernate.orm.jdbc.extract: TRACE

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,11 +14,11 @@ spring:
   jpa:
     hibernate:
       ddl-auto: create
-  properties:
-    hibernate:
-      show_sql: true
-      format_sql: true
-      use_sql_comments: true
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+        use_sql_comments: true
 logging:
   level:
     root: INFO

--- a/src/main/resources/templates/comment/comment.html
+++ b/src/main/resources/templates/comment/comment.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+qwewqe
+</body>
+</html>

--- a/src/main/resources/templates/comment/comment.html
+++ b/src/main/resources/templates/comment/comment.html
@@ -1,21 +1,16 @@
-<!DOCTYPE html>
-<html lang="ko"
-      data-theme="garden"
->
+<html layout:decorate="~{home/layout.html}">
 <head>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/tailwindcss/2.2.19/tailwind.min.css"/>
-    <link href="https://cdn.jsdelivr.net/npm/daisyui@2.51.6/dist/full.css" rel="stylesheet" type="text/css"/>
-    <script src="https://cdn.tailwindcss.com"></script>
-    <meta charset="UTF-8">
     <title>Title</title>
 </head>
 <body>
-<form th:action="@{|/comment/create/|}" method="POST">
-    <textarea placeholder="댓글을 입력해주세요." name = "content"
+<main layout:fragment="main">
+    <form th:action="@{/comment/create}" th:object="${commentForm}" method="POST">
+    <textarea placeholder="댓글을 입력해주세요." th:field="*{content}"
               class="bg-white textarea textarea-bordered textarea-sm w-full max-w-xs"></textarea>
-    <button type="submit" class="bg-blue-500 text-white font-bold py-2 px-4 rounded">
-        <span>입력</span>
-    </button>
-</form>
+        <button type="submit" class="bg-blue-500 text-white font-bold py-2 px-4 rounded">
+            <span>입력</span>
+        </button>
+    </form>
+</main>
 </body>
 </html>

--- a/src/main/resources/templates/comment/comment.html
+++ b/src/main/resources/templates/comment/comment.html
@@ -7,7 +7,7 @@
     <!-- 댓글 리스트 -->
 
     <!-- 댓글 작성 -->
-    <label for="comment" class="text-lg font-bold">댓글</label>
+    <label for="content" class="text-lg font-bold">댓글</label>
     <form th:action="@{/comment/create}" th:object="${commentForm}" method="POST">
     <textarea placeholder="댓글을 입력해주세요." th:field="*{content}" columns="4"
               class="border border-gray-300 rounded-lg textarea-lg w-6/12 focus:outline-none focus:ring-2 focus:ring-blue-400"></textarea>

--- a/src/main/resources/templates/comment/comment.html
+++ b/src/main/resources/templates/comment/comment.html
@@ -4,13 +4,19 @@
 </head>
 <body>
 <main layout:fragment="main">
+    <!-- 댓글 리스트 -->
+
+    <!-- 댓글 작성 -->
+    <label for="comment" class="text-lg font-bold">댓글</label>
     <form th:action="@{/comment/create}" th:object="${commentForm}" method="POST">
-    <textarea placeholder="댓글을 입력해주세요." th:field="*{content}"
-              class="bg-white textarea textarea-bordered textarea-sm w-full max-w-xs"></textarea>
-        <button type="submit" class="bg-blue-500 text-white font-bold py-2 px-4 rounded">
-            <span>입력</span>
+    <textarea placeholder="댓글을 입력해주세요." th:field="*{content}" columns="4"
+              class="border border-gray-300 rounded-lg textarea-lg w-6/12 focus:outline-none focus:ring-2 focus:ring-blue-400"></textarea>
+        <button type="submit" class="bg-blue-500 text-white py-2 px-4 rounded-lg hover:bg-blue-600">
+            <span>댓글 작성</span>
         </button>
     </form>
+
+    <!-- 대댓글 작성 -->
 </main>
 </body>
 </html>

--- a/src/main/resources/templates/comment/comment.html
+++ b/src/main/resources/templates/comment/comment.html
@@ -1,10 +1,21 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ko"
+      data-theme="garden"
+>
 <head>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/tailwindcss/2.2.19/tailwind.min.css"/>
+    <link href="https://cdn.jsdelivr.net/npm/daisyui@2.51.6/dist/full.css" rel="stylesheet" type="text/css"/>
+    <script src="https://cdn.tailwindcss.com"></script>
     <meta charset="UTF-8">
     <title>Title</title>
 </head>
 <body>
-qwewqe
+<form th:action="@{|/comment/create/|}" method="POST">
+    <textarea placeholder="댓글을 입력해주세요." name = "content"
+              class="bg-white textarea textarea-bordered textarea-sm w-full max-w-xs"></textarea>
+    <button type="submit" class="bg-blue-500 text-white font-bold py-2 px-4 rounded">
+        <span>입력</span>
+    </button>
+</form>
 </body>
 </html>

--- a/src/test/java/site/soloforest/soloforest/boundedContext/comment/service/CommentServiceTests.java
+++ b/src/test/java/site/soloforest/soloforest/boundedContext/comment/service/CommentServiceTests.java
@@ -19,7 +19,6 @@ import site.soloforest.soloforest.boundedContext.comment.repository.CommentRepos
 @SpringBootTest
 @AutoConfigureMockMvc
 @Transactional
-@Rollback(false)
 @ActiveProfiles("test")
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class CommentServiceTests {
@@ -30,17 +29,42 @@ public class CommentServiceTests {
 	private CommentRepository commentRepository;
 
 	@Test
-	@DisplayName("comment test")
+	@DisplayName("댓글 생성 테스트")
 	void t01() {
 		// 댓글 생성 //
 		Comment comment = commentService.create("테스트 댓글");
 
+		// 조회
 		Comment comment1 = commentRepository.findByContent("테스트 댓글");
 		assertThat(comment.equals(comment1));
 
 	}
 
+	@Test
+	@DisplayName("댓글 수정 테스트")
+	void t02() {
+		// 댓글 생성
+		Comment comment = commentService.create("테스트 댓글");
 
+		// 댓글 수정
+		Comment comment2 = commentService.modify(comment, "수정!");
+
+		assertThat(comment2.getContent().equals("수정!"));
+	}
+
+	@Test
+	@DisplayName("댓글 삭제 테스트")
+	void t03() {
+		// 댓글 생성
+		Comment comment = commentService.create("테스트 댓글");
+
+		// 댓글 삭제
+		commentService.delete(comment);
+
+		comment = commentService.getComment("테스트 댓글");
+
+		assertThat(comment).isNull();
+	}
 
 
 }

--- a/src/test/java/site/soloforest/soloforest/boundedContext/comment/service/CommentServiceTests.java
+++ b/src/test/java/site/soloforest/soloforest/boundedContext/comment/service/CommentServiceTests.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,6 +19,7 @@ import site.soloforest.soloforest.boundedContext.comment.repository.CommentRepos
 @SpringBootTest
 @AutoConfigureMockMvc
 @Transactional
+@Rollback(false)
 @ActiveProfiles("test")
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class CommentServiceTests {

--- a/src/test/java/site/soloforest/soloforest/boundedContext/comment/service/CommentServiceTests.java
+++ b/src/test/java/site/soloforest/soloforest/boundedContext/comment/service/CommentServiceTests.java
@@ -1,0 +1,44 @@
+package site.soloforest.soloforest.boundedContext.comment.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import site.soloforest.soloforest.boundedContext.comment.entity.Comment;
+import site.soloforest.soloforest.boundedContext.comment.repository.CommentRepository;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@ActiveProfiles("test")
+@TestMethodOrder(MethodOrderer.MethodName.class)
+public class CommentServiceTests {
+	@Autowired
+	private CommentService commentService;
+
+	@Autowired
+	private CommentRepository commentRepository;
+
+	@Test
+	@DisplayName("comment test")
+	void t01() {
+		// 댓글 생성 //
+		Comment comment = commentService.create("테스트 댓글");
+
+		Comment comment1 = commentRepository.findByContent("테스트 댓글");
+		assertThat(comment.equals(comment1));
+
+	}
+
+
+
+
+}


### PR DESCRIPTION
### ✅ **Summary**

- **complete** : 우선 간단하게 댓글 CRUD 했어요. 게시물, 로그인이 되어야 좀 더 할꺼같습니다.
- **note** :  뭔가 작성자 매칭, 댓글 리스트가 없으니 뭐부터 할지 모르겠어서 간단하게만 만들어 봤습니다. 계정생성이나 게시물 올리는거 기능먼저 되시면 NotProd처럼 개발 데이터 만들면 좋을 것 같아여

### ✅ **next plan**
  - 댓글 리스트 보여주기
  - 수정, 삭제버튼 추가
  - 댓글 작성자와 매칭CRUD
  - 비밀댓글 기능
  - 대댓글 기능

Close #15 