### PR TITLE
enhancement28/comment

### DIFF
--- a/src/main/java/site/soloforest/soloforest/boundedContext/article/repository/ArticleRepository.java
+++ b/src/main/java/site/soloforest/soloforest/boundedContext/article/repository/ArticleRepository.java
@@ -1,0 +1,8 @@
+package site.soloforest.soloforest.boundedContext.article.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import site.soloforest.soloforest.boundedContext.article.entity.Article;
+
+public interface ArticleRepository extends JpaRepository<Article, Long> {
+}

--- a/src/main/java/site/soloforest/soloforest/boundedContext/article/service/ArticleService.java
+++ b/src/main/java/site/soloforest/soloforest/boundedContext/article/service/ArticleService.java
@@ -1,0 +1,17 @@
+package site.soloforest.soloforest.boundedContext.article.service;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import site.soloforest.soloforest.boundedContext.article.entity.Article;
+import site.soloforest.soloforest.boundedContext.article.repository.ArticleRepository;
+
+@Service
+@RequiredArgsConstructor
+public class ArticleService {
+	private final ArticleRepository articleRepository;
+
+	public Article getArticle(Long id) {
+		return articleRepository.findById(id).get();
+	}
+}

--- a/src/main/java/site/soloforest/soloforest/boundedContext/comment/controller/CommentController.java
+++ b/src/main/java/site/soloforest/soloforest/boundedContext/comment/controller/CommentController.java
@@ -107,8 +107,8 @@ public class CommentController {
 		if (!comment.getWriter().getUsername().equals(principal.getName()))
 			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "수정권한이 없습니다");
 
-		// 비밀 댓글 여부 변경할 수 있으니 입력받는 객체 자체를 넘기기로 변경
-		commentService.modify(comment, commentForm);
+		// 댓글 내용, 비밀 댓글 여부만 수정 할테니 해당 값 넘기기
+		commentService.modify(comment, commentForm.getContent(), commentForm.getSecret());
 		// TODO : 게시글 정보로 리다이렉트 변경
 		return "redirect:/main";
 	}
@@ -123,6 +123,7 @@ public class CommentController {
 			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "삭제권한이 없습니다");
 		}
 		commentService.delete(comment);
+		// TODO : 게시글 정보로 리다이렉트
 		return "comment/comment";
 	}
 

--- a/src/main/java/site/soloforest/soloforest/boundedContext/comment/controller/CommentController.java
+++ b/src/main/java/site/soloforest/soloforest/boundedContext/comment/controller/CommentController.java
@@ -22,6 +22,7 @@ import lombok.Setter;
 import lombok.Value;
 import site.soloforest.soloforest.boundedContext.account.entity.Account;
 import site.soloforest.soloforest.boundedContext.article.entity.Article;
+import site.soloforest.soloforest.boundedContext.article.service.ArticleService;
 import site.soloforest.soloforest.boundedContext.comment.entity.Comment;
 import site.soloforest.soloforest.boundedContext.comment.service.CommentService;
 
@@ -32,6 +33,8 @@ public class CommentController {
 
 	// private final ArticleService articleService;
 	private final CommentService commentService;
+
+	private final ArticleService articleService;
 
 	// 디버깅시 활용
 	// private static final Logger logger = LoggerFactory.getLogger(CommentController.class);
@@ -62,10 +65,8 @@ public class CommentController {
 
 		// 게시글 id를 가져오고, 현재 로그인한 회원의 정보, 댓글 폼에 입력한 내용으로 댓글 객체 생성
 		Article article = articleService.getArticle(id);
-		Account account = AccoutService.getUser(principal.getName());
-		Comment comment = commentService.create(commentForm, account);
-
-		Comment comment= commentService.create(commentForm, account, article);
+		// Account account = AccoutService.getUser(principal.getName());
+		// Comment comment= commentService.create(commentForm, account, article);
 
 		return "redirect:/main";
 

--- a/src/main/java/site/soloforest/soloforest/boundedContext/comment/controller/CommentController.java
+++ b/src/main/java/site/soloforest/soloforest/boundedContext/comment/controller/CommentController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.server.ResponseStatusException;
+import org.springframework.ui.Model;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
@@ -18,6 +19,9 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
+import lombok.Value;
+import site.soloforest.soloforest.boundedContext.account.entity.Account;
+import site.soloforest.soloforest.boundedContext.article.entity.Article;
 import site.soloforest.soloforest.boundedContext.comment.entity.Comment;
 import site.soloforest.soloforest.boundedContext.comment.service.CommentService;
 
@@ -26,12 +30,14 @@ import site.soloforest.soloforest.boundedContext.comment.service.CommentService;
 @RequestMapping("/comment")
 public class CommentController {
 
+	// private final ArticleService articleService;
 	private final CommentService commentService;
 
 	// 디버깅시 활용
 	// private static final Logger logger = LoggerFactory.getLogger(CommentController.class);
 	// 	logger.info("showComment 메서드 호출");
 
+	// 삭제 예정(댓글 자체는 게시글 조회시 자동으로 나오게)
 	@GetMapping("")
 	public String showComment(CommentForm commentForm) {
 		return "comment/comment";
@@ -43,14 +49,28 @@ public class CommentController {
 	public static class CommentForm {
 		@NotBlank(message = "내용은 필수로 입력해야 합니다.")
 		private String content;
+
+		// 기본값 false로 설정
+		private Boolean secret = false;
 	}
 
 	// @PreAuthorize("isAuthenticated()")
-	// user의 Username 가져와서 작성자 정보도 업로드 수정
-	@PostMapping("/create")
-	public String create(@Valid CommentForm commentForm) {
-		Comment comment= commentService.create(commentForm.getContent());
+	// ToDO : 게시글 id를 통해 게시글을 얻고, 현재 로그인한 회원의 사용자 정보도 얻어서 등록한다.
+	// ToDo : 대댓글 방식은 PostMapping을 추가하고, 댓글 id를 가지고 build를 하면 될 것 같은데 좀 더 고민해보기!
+	@PostMapping("/create/{id}")
+	public String create(Model model, @PathVariable("id") Long id, @Valid CommentForm commentForm, Principal principal) {
+
+		// 게시글 id를 가져오고, 현재 로그인한 회원의 정보, 댓글 폼에 입력한 내용으로 댓글 객체 생성
+		Article article = articleService.getArticle(id);
+		Account account = AccoutService.getUser(principal.getName());
+		Comment comment = commentService.create(commentForm, account);
+
+		Comment comment= commentService.create(commentForm, account, article);
+
 		return "redirect:/main";
+
+		// TODO : 댓글 작성 시 게시글로 리다이렉트
+		// return "redirect:/article/detail/%s".formatted(id);
 	}
 
 	// @PreAuthorize("isAuthenticated()")
@@ -61,6 +81,9 @@ public class CommentController {
 			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "수정권한이 없습니다");
 		}
 		commentForm.setContent(comment.getContent());
+		// 비밀 댓글 여부도 변경했을 수 있으니 비밀 댓글 속성도 값 가져오도록 수정
+		commentForm.setSecret(comment.getSecret());
+		// TODO : 다시 게시글 정보로 돌아가는 리다이렉트로 수정
 		return "comment/comment";// 댓글 폼 html
 	}
 
@@ -72,7 +95,9 @@ public class CommentController {
 		if(!comment.getWriter().getUsername().equals(principal.getName()))
 			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "수정권한이 없습니다");
 
-		commentService.modify(comment, commentForm.getContent());
+		// 비밀 댓글 여부 변경할 수 있으니 입력받는 객체 자체를 넘기기로 변경
+		commentService.modify(comment, commentForm);
+		// TODO : 게시글 정보로 리다이렉트 변경
 		return "redirect:/main";
 	}
 

--- a/src/main/java/site/soloforest/soloforest/boundedContext/comment/entity/Comment.java
+++ b/src/main/java/site/soloforest/soloforest/boundedContext/comment/entity/Comment.java
@@ -66,4 +66,15 @@ public class Comment {
 	@OneToOne
 	private Notification notification;
 
+	public void deleteParent(){
+		this.content = "삭제되었습니다.";
+	}
+
+	// 타임리프에서 비밀 댓글이면 댓글의 내용이 안보이게 하기 위함
+	// TODO : 템플릿에서 th:if(비밀글) => th:text = "비밀 댓글입니다."
+	//  + (사용자 id = 작성자 or admin or 게시글 작성자만 보이게 타임리프 조건)
+ 	public boolean isSecret() {
+		return this.secret == true;
+	}
+
 }

--- a/src/main/java/site/soloforest/soloforest/boundedContext/comment/service/CommentService.java
+++ b/src/main/java/site/soloforest/soloforest/boundedContext/comment/service/CommentService.java
@@ -63,10 +63,10 @@ public class CommentService {
 
 	// 댓글 수정
 	@Transactional
-	public Comment modify(Comment comment, CommentController.CommentForm commentForm) {
+	public Comment modify(Comment comment, String content, boolean secret) {
 		Comment mComment = comment.toBuilder()
-			.content(commentForm.getContent())
-			.secret(commentForm.getSecret())
+			.content(content)
+			.secret(secret)
 			.build();
 		commentRepository.save(mComment);
 

--- a/src/main/java/site/soloforest/soloforest/boundedContext/comment/service/CommentService.java
+++ b/src/main/java/site/soloforest/soloforest/boundedContext/comment/service/CommentService.java
@@ -20,12 +20,12 @@ public class CommentService {
 
 	// TODO : 댓글 생성시 댓글 생성 알림 객체 생성 및 등록
 	@Transactional
-	public Comment create(CommentController.CommentForm commentForm, Account account, Article article) {
+	public Comment create(String content, boolean secret, Account account, Article article) {
 		Comment newComment = Comment.builder()
-			.content(commentForm.getContent())
+			.content(content)
 			.writer(account)
 			.article(article)
-			.secret(commentForm.getSecret())
+			.secret(secret)
 			.build();
 
 		// 알림 객체 생성 이벤트 발생
@@ -35,6 +35,26 @@ public class CommentService {
 
 		return newComment;
 	}
+
+	// TODO : 댓글 생성시 댓글 생성 알림 객체 생성 및 등록
+	@Transactional
+	public Comment createReplyComment(String content, boolean secret, Account account, Article article, Comment parentComment) {
+		Comment newComment = Comment.builder()
+			.content(content)
+			.writer(account)
+			.article(article)
+			.secret(secret)
+			.parent(parentComment)
+			.build();
+
+		// 대댓글 알림 객체 생성 이벤트 발생
+
+
+		commentRepository.save(newComment);
+
+		return newComment;
+	}
+
 
 	// 테스트용
 	public Comment getComment(Long commentId) {

--- a/src/main/resources/templates/comment/comment.html
+++ b/src/main/resources/templates/comment/comment.html
@@ -1,22 +1,47 @@
 <html layout:decorate="~{home/layout.html}">
 <head>
-    <title>Title</title>
+    <title>댓글테스트</title>
 </head>
 <body>
 <main layout:fragment="main">
-    <!-- 댓글 리스트 -->
+    <ul class="space-y-4">
+        <li>
+            <div class="border p-4 rounded-lg flex justify-between">
+                <p class="text-lg font-bold">댓글: 테스트</p>
+                <p class="text-gray-500">작성자: 테스트</p>
+            </div>
+            <ul class="ml-4 space-y-2">
+                <li>
+                    <div class="border-t border-gray-300 p-4 rounded-lg flex items-center">
+                        <div class="flex items-center flex-grow">
+                            <i class="fa-regular fa-arrow-turn-down-right" style="color: #ffdd00;"></i>
+                            <p class="text-lg font-bold ml-2">대댓글: 대댓글이다!</p>
+                        </div>
+                        <p class="text-gray-500">작성자: 테스트!</p>
+                    </div>
+                </li>
+            </ul>
+            <hr class="my-4" />
+        </li>
+    </ul>
+
+    <hr class="my-4" />
 
     <!-- 댓글 작성 -->
     <label for="content" class="text-lg font-bold">댓글</label>
     <form th:action="@{/comment/create}" th:object="${commentForm}" method="POST">
     <textarea placeholder="댓글을 입력해주세요." th:field="*{content}" columns="4"
-              class="border border-gray-300 rounded-lg textarea-lg w-6/12 focus:outline-none focus:ring-2 focus:ring-blue-400"></textarea>
+              class="border border-gray-300 rounded-lg textarea-lg w-full focus:outline-none focus:ring-2 focus:ring-blue-400"></textarea>
+        <div>
+            <label class="label cursor-pointer">
+                <span class="label-text">비밀 댓글</span>
+                <input type="checkbox" th:field="*{secret}" />
+            </label>
+        </div>
         <button type="submit" class="bg-blue-500 text-white py-2 px-4 rounded-lg hover:bg-blue-600">
             <span>댓글 작성</span>
         </button>
     </form>
-
-    <!-- 대댓글 작성 -->
 </main>
 </body>
 </html>

--- a/src/test/java/site/soloforest/soloforest/boundedContext/comment/service/CommentServiceTests.java
+++ b/src/test/java/site/soloforest/soloforest/boundedContext/comment/service/CommentServiceTests.java
@@ -2,6 +2,7 @@ package site.soloforest.soloforest.boundedContext.comment.service;
 
 import static org.assertj.core.api.Assertions.*;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Test;
@@ -9,10 +10,16 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
+import site.soloforest.soloforest.boundedContext.account.entity.Account;
+import site.soloforest.soloforest.boundedContext.account.repository.AccountRepository;
+import site.soloforest.soloforest.boundedContext.article.entity.Article;
+import site.soloforest.soloforest.boundedContext.article.entity.Share;
+import site.soloforest.soloforest.boundedContext.article.service.ShareService;
 import site.soloforest.soloforest.boundedContext.comment.entity.Comment;
 import site.soloforest.soloforest.boundedContext.comment.repository.CommentRepository;
 
@@ -26,44 +33,61 @@ public class CommentServiceTests {
 	private CommentService commentService;
 
 	@Autowired
-	private CommentRepository commentRepository;
+	private ShareService shareService;
 
+	@Autowired
+	private AccountRepository accountRepository;
+
+	@Autowired
+	private PasswordEncoder passwordEncoder;
+
+	// @BeforeEach
+	// void initData() {
+	// 	// 회원 생성
+	// 	Account account = Account.builder()
+	// 		.username("usertest")
+	// 		.password(passwordEncoder.encode("test1"))
+	// 		.nickname("for test")
+	// 		.email("test@test.com")
+	// 		.build();
+	// 	this.accountRepository.save(account);
+	//
+	// 	// 게시글 작성
+	//
+	// 	Article tmp1 = Share.builder()
+	// 		.boardNumber(0)
+	// 		.subject("테스트제목1")
+	// 		.content("테스트내용1")
+	// 		.account(account)
+	// 		.build();
+	//
+	// 	// 댓글 작성
+	// 	Comment comment1 = commentService.create("테스트댓글1", false, account, tmp1);
+	// 	Comment comment2 = commentService.create("테스트댓글2", false, account, tmp1);
+	// 	Comment comment3 = commentService.create("테스트댓글3", false, account, tmp1);
+	// 	Comment comment4 = commentService.create("테스트댓글4", false, account, tmp1);
+	// 	Comment comment5 = commentService.create("테스트댓글5", false, account, tmp1);
+	// 	Comment comment6 = commentService.create("테스트댓글6", false, account, tmp1);
+	//
+	// }
+
+	// TODO : NotProd 생성 시 테스트케이스 작성
 	@Test
 	@DisplayName("댓글 생성 테스트")
 	void t01() {
-		// 댓글 생성 //
-		Comment comment = commentService.create("테스트 댓글");
-
-		// 조회
-		Comment comment1 = commentService.findById(1L);
-		assertThat(comment.equals(comment1));
 
 	}
 
 	@Test
 	@DisplayName("댓글 수정 테스트")
 	void t02() {
-		// 댓글 생성
-		Comment comment = commentService.create("테스트 댓글");
 
-		// 댓글 수정
-		Comment comment2 = commentService.modify(comment, "수정!");
-
-		assertThat(comment2.getContent().equals("수정!"));
 	}
 
 	@Test
 	@DisplayName("댓글 삭제 테스트")
 	void t03() {
-		// 댓글 생성
-		Comment comment = commentService.create("테스트 댓글");
 
-		// 댓글 삭제
-		commentService.delete(comment);
-
-		comment = commentService.getComment("테스트 댓글");
-
-		assertThat(comment).isNull();
 	}
 
 

--- a/src/test/java/site/soloforest/soloforest/boundedContext/comment/service/CommentServiceTests.java
+++ b/src/test/java/site/soloforest/soloforest/boundedContext/comment/service/CommentServiceTests.java
@@ -35,7 +35,7 @@ public class CommentServiceTests {
 		Comment comment = commentService.create("테스트 댓글");
 
 		// 조회
-		Comment comment1 = commentRepository.findByContent("테스트 댓글");
+		Comment comment1 = commentService.findById(1L);
 		assertThat(comment.equals(comment1));
 
 	}


### PR DESCRIPTION
### ✅ **Summary**

- **complete** : 
- [x] 비밀 댓글 기능 구현
- [x] 댓글, 대댓글 생성 및 삭제, 수정 구현
  - [x] 댓글 객체 생성을 위해 ArticleService를 도입하여 id찾기 
    => 뤼튼에 물어보니 DType에 해당하는 것만 id 나오는게 맞다고 하네영
    => [참조](https://www.notion.so/id-10f94354068b4f228f30bc730b74b0af?pvs=4)

- **note** : 
 - Read의 경우 타임리프로 할 것이라 NotProd가 되고 Article에서 레이아웃 적용시키면 테스트가 가능할 것 같습니다.
 - Account.getUser() 구현해주세요!
 - issue에 명시한거 다 못한 경우는 close를 안하고 다시 이어서 하나요? 아니면 다한것만으로 수정하고 close를 할까요?
 
### ✅ **next plan**
- 댓글 리스트 출력은 타임리프로만 해서 메서드가 필요 없을 것 같아요
  - 타임리프 적용으로 구현 예정(댓글 페이징 도전)
- 댓글, 대댓글 작성 시 글 작성자에게 알림 객체 생성 이벤트 작업
- 댓글에 앵커적용하고 시간 남으면 리액트 등 공부해서 댓글 달리면 새로고침 안되도록 한번 해보겠습니다.
- 그 외 알림기능