### PR TITLE
feat : 배포 자동화를 위한 prod.yml, 세션 외부 저장을 위한 redis 도입

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM openjdk:17-jdk-alpine
-ARG JAR_FILE=build/libs/soloForest-0.0.1-SNAPSHOT.jar
+ARG JAR_FILE=build/libs/*.jar
 COPY ${JAR_FILE} app.jar
 EXPOSE 8080
 ENTRYPOINT ["java","-jar","-Dspring.profiles.active=prod","/app.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM openjdk:17-jdk-alpine
+ARG JAR_FILE=build/libs/soloForest-0.0.1-SNAPSHOT.jar
+COPY ${JAR_FILE} app.jar
+EXPOSE 8080
+ENTRYPOINT ["java","-jar","-Dspring.profiles.active=prod","/app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,19 @@ dependencies {
     // 타임리프 레이아웃 디펜던시
     implementation 'nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect'
     implementation 'com.googlecode.json-simple:json-simple:1.1.1' // json
+
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+
+    // redis 드라이버
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    // 세션을 스프링 내부객체가 아닌 다른 저장소에 저장할 수 있도록 해주는 녀석
+    implementation 'org.springframework.session:spring-session-core'
+
+    // 세션을 redis
+    implementation 'org.springframework.session:spring-session-data-redis'
+
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -55,3 +55,8 @@ dependencies {
 tasks.named('test') {
     useJUnitPlatform()
 }
+
+
+jar {
+    enabled = false
+}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,39 @@
+server:
+  shutdown: graceful
+management:
+  endpoint:
+    health:
+      probes:
+        enabled: true
+  health:
+    livenessstate:
+      enabled: true
+    readinessstate:
+      enabled: true
+spring:
+  data:
+    redis:
+      host: 172.17.0.1
+  lifecycle:
+    timeout-per-shutdown-phase: 1m
+  autoconfigure:
+    exclude:
+  datasource:
+    driver-class-name: org.mariadb.jdbc.Driver
+    url: jdbc:mariadb://172.17.0.1:3306/soloforest__prod?useUnicode=true&characterEncoding=utf8&autoReconnect=true&serverTimezone=Asia/Seoul
+    username: lldjlocal
+    password: 1234
+  jpa:
+    hibernate:
+      ddl-auto: validate #엔티티와 테이블 매핑 여부만 확인
+    properties:
+      hibernate:
+        show_sql: false
+        format_sql: false
+        use_sql_comments: false
+logging:
+  level:
+    root: INFO
+    com.ll.soloForest: INFO
+    org.hibernate.orm.jdbc.bind: INFO
+    org.hibernate.orm.jdbc.extract: INFO

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,4 +1,8 @@
 spring:
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
+      - org.springframework.boot.autoconfigure.session.SessionAutoConfiguration
   datasource:
     driver-class-name: org.h2.Driver
     url: jdbc:h2:mem:test;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,6 +3,10 @@ spring:
     hiddenmethod:
       filter:
         enabled: true
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
+      - org.springframework.boot.autoconfigure.session.SessionAutoConfiguration
   profiles:
     active: dev
     include: secret


### PR DESCRIPTION
### ✅ **Summary**

- **complete** :
  - [x] 서버에서 도커 호스트를 통해 MariaDB에 접근하기 위해 prod.yml 생성
  - [x] 스프링부트가 아닌 외부에서 세션을 관리하도록 redis도입(운영모드에서만)
  - [x] 배포 자동화(해당 PR 승인 시 될 거에요!)

- **note** : 반영 되면 pull하시고 그래들 한번 돌려주세요!

Close #41
### ✅ **next plan**
- 쿠버네티스 해볼만 하다 싶으면 도전..!
- 알림 HTML, 댓글 작성 시 객체 생성
- 댓글 페이징 등