### PR TITLE
Enhancement53/withdraw

### DIFF
--- a/src/main/java/site/soloforest/soloforest/base/security/AccountAdapter.java
+++ b/src/main/java/site/soloforest/soloforest/base/security/AccountAdapter.java
@@ -1,0 +1,17 @@
+package site.soloforest.soloforest.base.security;
+
+import org.springframework.security.core.userdetails.User;
+
+import lombok.Getter;
+import site.soloforest.soloforest.boundedContext.account.entity.Account;
+
+@Getter
+public class AccountAdapter extends User {
+	private Account account;
+
+	public AccountAdapter(Account account) {
+		super(account.getUsername(), account.getPassword(), account.getGrantedAuthorities());
+
+		this.account = account;
+	}
+}

--- a/src/main/java/site/soloforest/soloforest/base/security/CustomUserDetailsService.java
+++ b/src/main/java/site/soloforest/soloforest/base/security/CustomUserDetailsService.java
@@ -1,6 +1,5 @@
 package site.soloforest.soloforest.base.security;
 
-import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -19,6 +18,6 @@ public class CustomUserDetailsService implements UserDetailsService {
 	public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
 		Account account = accountRepository.findByUsername(username)
 			.orElseThrow(() -> new UsernameNotFoundException("username(%s) not found".formatted(username)));
-		return new User(account.getUsername(), account.getPassword(), account.getGrantedAuthorities());
+		return new AccountAdapter(account);
 	}
 }

--- a/src/main/java/site/soloforest/soloforest/boundedContext/account/controller/AccountController.java
+++ b/src/main/java/site/soloforest/soloforest/boundedContext/account/controller/AccountController.java
@@ -67,8 +67,9 @@ public class AccountController {
 
 	@PostMapping("/me/{id}")
 	@PreAuthorize("isAuthenticated()")
-	public String modifyMe(@PathVariable Long id, @ModelAttribute ModifyForm input, Model model) {
-		Account entity = accountService.modifyInfo(id, input);
+	public String modifyMe(@PathVariable Long id, @ModelAttribute ModifyForm input,
+		Model model, HttpServletRequest request) {
+		Account entity = accountService.modifyInfo(id, input, request);
 		if (entity == null)
 			return "redirect:/account/me?error=true";
 		model.addAttribute("account", entity);

--- a/src/main/java/site/soloforest/soloforest/boundedContext/account/controller/AccountController.java
+++ b/src/main/java/site/soloforest/soloforest/boundedContext/account/controller/AccountController.java
@@ -2,7 +2,10 @@ package site.soloforest.soloforest.boundedContext.account.controller;
 
 import java.security.Principal;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -10,10 +13,13 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import site.soloforest.soloforest.base.security.AccountAdapter;
 import site.soloforest.soloforest.boundedContext.account.dto.AccountDTO;
 import site.soloforest.soloforest.boundedContext.account.dto.ModifyForm;
 import site.soloforest.soloforest.boundedContext.account.entity.Account;
@@ -67,5 +73,17 @@ public class AccountController {
 			return "redirect:/account/me?error=true";
 		model.addAttribute("account", entity);
 		return "redirect:/account/me";
+	}
+
+	@PostMapping("/withdraw/{id}")
+	@PreAuthorize("isAuthenticated()")
+	@ResponseBody
+	public ResponseEntity<String> withdraw(@PathVariable Long id, @RequestParam("password") String password,
+		@AuthenticationPrincipal AccountAdapter accountAdapter, HttpServletRequest request) {
+		if (!accountAdapter.getAccount().getId().equals(id)) {
+			return new ResponseEntity<>("Authentication failed", HttpStatus.UNAUTHORIZED);
+		}
+
+		return accountService.withdraw(accountAdapter.getAccount(), password, request);
 	}
 }

--- a/src/main/java/site/soloforest/soloforest/boundedContext/account/entity/Account.java
+++ b/src/main/java/site/soloforest/soloforest/boundedContext/account/entity/Account.java
@@ -65,6 +65,8 @@ public class Account {
 	private int authority = 1;
 	@Builder.Default
 	private int reported = 0;
+	@Builder.Default
+	private boolean deleted = false;
 
 	@OneToMany(cascade = {CascadeType.REMOVE})
 	@ToString.Exclude

--- a/src/main/java/site/soloforest/soloforest/boundedContext/account/service/AccountService.java
+++ b/src/main/java/site/soloforest/soloforest/boundedContext/account/service/AccountService.java
@@ -2,6 +2,8 @@ package site.soloforest.soloforest.boundedContext.account.service;
 
 import java.util.Optional;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.DisabledException;
@@ -146,5 +148,36 @@ public class AccountService {
 			return false;
 		}
 		return true;
+	}
+
+	public ResponseEntity<String> withdraw(Account account, String password, HttpServletRequest request) {
+		if (account != null) {
+			if (passwordEncoder.matches(password, account.getPassword())) {
+				account.setUsername(null);
+				account.setNickname(null);
+				account.setEmail(null);
+				account.setAddress(null);
+				account.setImageUrl(null);
+				account.setDeleted(true);
+
+				accountRepository.save(account);
+				logoutAndInvalidateSession(request);
+				return new ResponseEntity<>("Account has been successfully deleted", HttpStatus.OK);
+			} else {
+				return new ResponseEntity<>("Incorrect password", HttpStatus.BAD_REQUEST);
+			}
+		} else {
+			return new ResponseEntity<>("Account does not exist", HttpStatus.NOT_FOUND);
+		}
+	}
+
+	private void logoutAndInvalidateSession(HttpServletRequest request) {
+		HttpSession session = request.getSession(false);
+
+		if (session != null) {
+			session.invalidate();
+		}
+
+		SecurityContextHolder.clearContext();
 	}
 }

--- a/src/main/resources/static/common/validator.js
+++ b/src/main/resources/static/common/validator.js
@@ -91,3 +91,37 @@ function ModifyForm__submit(form) {
 
     form.submit();
 }
+
+function Withdraw__Submit(form) {
+    let isConfirm = confirm('탈퇴한 회원은 복구할 수 없습니다.\n그래도 탈퇴하시겠습니까?');
+    if (isConfirm === true) {
+        let input = prompt('비밀번호를 입력해주세요.');
+        if (input != null && passwordValueMinLength <= input.trim().length && input.trim().length <= passwordValueMaxLength) {
+            let header = $("meta[name='_csrf_header']").attr('content');
+            let token = $("meta[name='_csrf']").attr('content');
+
+            $.ajax({
+                url: form.action,
+                type: "POST",
+                data: {
+                    _csrf: form._csrf.value,
+                    password: input
+                },
+                beforeSend: function (xhr) {
+                    xhr.setRequestHeader(header, token);
+                },
+                success: function (result) {
+                    alert('탈퇴 완료');
+                    window.location.href = '/main';
+                },
+                error: function (request, status, error) {
+                    alert('올바르지 않은 비밀번호입니다.');
+                }
+            })
+        } else if (passwordValueMinLength > input.trim().length || passwordValueMaxLength < input.trim().length)
+            alert('올바르지 않은 비밀번호입니다.');
+        else {
+            alert('취소되었습니다.');
+        }
+    }
+}

--- a/src/main/resources/templates/account/me.html
+++ b/src/main/resources/templates/account/me.html
@@ -3,6 +3,10 @@
     <title>my page</title>
     <Script src="/common/validator.js"></Script>
     <script src="/common/addressDropdown.js"></script>
+
+    <meta name="_csrf_header" th:content="${_csrf.headerName}">
+    <meta name="_csrf" th:content="${_csrf.token}">
+
     <style>
         .input-group span {
             width: 100px;
@@ -31,76 +35,83 @@
             $('#modifySubmit').removeClass("hidden-input");
         }
     </script>
-    <form method="POST" th:action="|/account/me/${account.id}|" onsubmit="ModifyForm__submit(this); return false;"
-          class="gap-5 my-16 flex  flex-col justify-center items-center flex-grow">
-        <h1 class="text-xl font-bold">My Account</h1>
-        <img id="profile" class="max-w-xs min-w-xs mask mask-circle shadow-2xl" src="/profile-00000001.jpg"/>
-        <input id="imageUrl" name="imageUrl" type="file"
-               class="file-input file-input-bordered file-input-primary w-full max-w-xs hidden-input"/>
+    <div class="my-16 flex flex-col justify-center items-center flex-grow">
+        <form method="POST" th:action="|/account/me/${account.id}|" onsubmit="ModifyForm__submit(this); return false;"
+              class="gap-5 flex flex-col justify-center items-center flex-grow">
+            <h1 class="text-xl font-bold">My Account</h1>
+            <img id="profile" class="max-w-[250px] min-w-[250px] mask mask-circle shadow-2xl"
+                 src="/profile-00000001.jpg"/>
+            <input id="imageUrl" name="imageUrl" type="file"
+                   class="file-input file-input-bordered file-input-primary w-full max-w-xs hidden-input"/>
 
-        <div id="passwordText" class="form-control hidden-input">
-            <label class="input-group max-w-sm min-w-sm">
-                <span>Password</span>
-                <input id="password" name="password" type="password" placeholder="password"
-                       class="input input-bordered"/>
-            </label>
-        </div>
-        <div id="passwordCheckText" class="form-control hidden-input">
-            <label class="input-group max-w-sm min-w-sm">
-                <span>Password Check</span>
-                <input id="passwordCheck" name="passwordCheck" type="password" placeholder="password"
-                       class="input input-bordered"/>
-            </label>
-        </div>
+            <div id="passwordText" class="form-control hidden-input">
+                <label class="input-group max-w-sm min-w-sm">
+                    <span>Password</span>
+                    <input id="password" name="password" type="password" placeholder="password"
+                           class="input input-bordered"/>
+                </label>
+            </div>
+            <div id="passwordCheckText" class="form-control hidden-input">
+                <label class="input-group max-w-sm min-w-sm">
+                    <span>Password Check</span>
+                    <input id="passwordCheck" name="passwordCheck" type="password" placeholder="password"
+                           class="input input-bordered"/>
+                </label>
+            </div>
 
-        <div class="form-control">
-            <label class="input-group max-w-sm min-w-sm">
-                <span>Nickname</span>
-                <input id="nickname" name="nickname" type="text" placeholder="nickname" class="input input-bordered"
-                       disabled
-                       th:value="${account.nickname}"/>
-            </label>
-        </div>
+            <div class="form-control">
+                <label class="input-group max-w-sm min-w-sm">
+                    <span>Nickname</span>
+                    <input id="nickname" name="nickname" type="text" placeholder="nickname" class="input input-bordered"
+                           disabled
+                           th:value="${account.nickname}"/>
+                </label>
+            </div>
 
-        <div class="form-control">
-            <label class="input-group">
-                <span>Email</span>
-                <input id="email" name="email" type="text" placeholder="yours@site.com" class="input input-bordered"
-                       disabled
-                       th:value="${account.email}"/>
-            </label>
-        </div>
+            <div class="form-control">
+                <label class="input-group">
+                    <span>Email</span>
+                    <input id="email" name="email" type="text" placeholder="yours@site.com" class="input input-bordered"
+                           disabled
+                           th:value="${account.email}"/>
+                </label>
+            </div>
 
-        <div id="addressDropdown" class="input-group hidden-input">
-            <select id="do" class="select select-bordered w-full max-w-[160px]">
-                <option value="">도 선택</option>
-            </select>
-            <select id="si" class="select select-bordered w-full max-w-[160px]">
-                <option value="">시 선택</option>
-            </select>
-        </div>
-        <div id="addressText">
-            <label class="input-group">
-                <span>Address</span>
-                <input id="address" name="address" type="text" placeholder="your address" class="input input-bordered"
-                       disabled th:value="${account.address}"/>
-            </label>
-        </div>
+            <div id="addressDropdown" class="input-group hidden-input">
+                <select id="do" class="select select-bordered w-full max-w-[160px]">
+                    <option value="">도 선택</option>
+                </select>
+                <select id="si" class="select select-bordered w-full max-w-[160px]">
+                    <option value="">시 선택</option>
+                </select>
+            </div>
+            <div id="addressText">
+                <label class="input-group">
+                    <span>Address</span>
+                    <input id="address" name="address" type="text" placeholder="your address"
+                           class="input input-bordered"
+                           disabled th:value="${account.address}"/>
+                </label>
+            </div>
 
+            <div id="modify-group" class="self-end">
+                <button id="modifyActive" class="btn btn-outline btn-primary" onclick="modify_active();" type="button">
+                    변경하기
+                </button>
+                <a id="modifyCancel" href="/account/me" class="btn btn-outline btn-error hidden-input">
+                    변경 취소
+                </a>
+                <button id="modifySubmit" class="btn btn-primary hidden-input">
+                    변경완료
+                </button>
+            </div>
+        </form>
 
-        <div id="modify-group" class="self-end">
-            <button id="modifyActive" class="btn btn-outline btn-primary" onclick="modify_active();" type="button">
-                변경하기
-            </button>
-            <a id="modifyCancel" href="/account/me" class="btn btn-outline btn-error hidden-input">
-                변경 취소
-            </a>
-            <button id="modifySubmit" class="btn btn-primary hidden-input">
-                변경완료
-            </button>
-        </div>
-        <a class="link link-error self-start" onclick="">혼숲 탈퇴하기</a>
-    </form>
+        <form method="POST" th:action="|/account/withdraw/${account.id}|" style="display: inline"
+              onsubmit="Withdraw__Submit(this); return false;" class="self-start">
+            <button class="link link-error self-start">혼숲 탈퇴하기</button>
+        </form>
+    </div>
 </main>
 </body>
 </html>

--- a/src/test/java/site/soloforest/soloforest/boundedContext/account/controller/AccountControllerTest.java
+++ b/src/test/java/site/soloforest/soloforest/boundedContext/account/controller/AccountControllerTest.java
@@ -232,4 +232,43 @@ public class AccountControllerTest {
 		assertThat(accountRepository.findById(2L).get().getNickname()).isEqualTo("somsom");
 		assertThat(oldPassword).isNotEqualTo(accountRepository.findById(2L).get().getPassword());
 	}
+
+	@Test
+	@DisplayName("회원탈퇴 테스트 - 실패하는 경우")
+	@WithUserDetails("usertest")
+	void t010() throws Exception {
+		ResultActions resultActions = mvc
+			.perform(post("/account/withdraw/2")
+				.with(csrf())
+				.param("password", "bbosong1")
+			)
+			.andDo(print());
+
+		resultActions
+			.andExpect(handler().handlerType(AccountController.class))
+			.andExpect(handler().methodName("withdraw"))
+			.andExpect(status().isBadRequest());
+
+		assertThat(accountRepository.findById(2L).get().getNickname()).isEqualTo("for test");
+	}
+
+	@Test
+	@DisplayName("회원탈퇴 테스트 - 성공하는 경우")
+	@WithUserDetails("usertest")
+	void t011() throws Exception {
+		ResultActions resultActions = mvc
+			.perform(post("/account/withdraw/2")
+				.with(csrf())
+				.param("password", "test1")
+			)
+			.andDo(print());
+
+		resultActions
+			.andExpect(handler().handlerType(AccountController.class))
+			.andExpect(handler().methodName("withdraw"))
+			.andExpect(status().isOk());
+
+		assertThat(accountRepository.findById(2L).get().getNickname()).isEqualTo("알 수 없는 이용자");
+		assertThat(accountRepository.findByUsername("usertest")).isEmpty();
+	}
 }


### PR DESCRIPTION
### ✅ **Summary**

**complete** :
- [x] 회원탈퇴 테스트 작성
- [x] front : 계정 비밀번호를 입력받고 일치하면 탈퇴요청
- back : 탈퇴처리
  - [x] username, password, nickname, email, imageUrl -> null
  - [x] deleted -> true
  - [x] 세션 삭제(로그아웃) 
- getNickname() 덮어쓰기
  - [x] nickname이 null이면 '알 수 없는 이용자'로 대체

**note** :
- 비밀번호 변경 직후 탈퇴하려면 기존의 비밀번호 입력해야하는 문제 발생
  - 비밀번호가 변경되면 password 정보가 담긴 세션을 새로운 비밀번호가 담긴 세션으로 교체하도록 했습니다.

### ✅ **next plan**
- id/pw 찾기 구현
- 신고 기능 구현

Close #53 