### PR TITLE
Enhancement68/report

### DIFF
--- a/src/main/java/site/soloforest/soloforest/base/error/ErrorController.java
+++ b/src/main/java/site/soloforest/soloforest/base/error/ErrorController.java
@@ -1,0 +1,24 @@
+package site.soloforest.soloforest.base.error;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import jakarta.servlet.http.HttpServletResponse;
+
+@Controller
+@RequestMapping("/error")
+public class ErrorController {
+	@GetMapping("/404")
+	public String notFound(HttpServletResponse response) {
+		response.setStatus(HttpStatus.NOT_FOUND.value());
+		return "/error/404";
+	}
+
+	@GetMapping("/403")
+	public String forbidden(HttpServletResponse response) {
+		response.setStatus(HttpStatus.FORBIDDEN.value());
+		return "/error/403";
+	}
+}

--- a/src/main/java/site/soloforest/soloforest/base/error/ErrorController.java
+++ b/src/main/java/site/soloforest/soloforest/base/error/ErrorController.java
@@ -13,12 +13,18 @@ public class ErrorController {
 	@GetMapping("/404")
 	public String notFound(HttpServletResponse response) {
 		response.setStatus(HttpStatus.NOT_FOUND.value());
-		return "/error/404";
+		return "error/404";
 	}
 
 	@GetMapping("/403")
 	public String forbidden(HttpServletResponse response) {
 		response.setStatus(HttpStatus.FORBIDDEN.value());
-		return "/error/403";
+		return "error/403";
+	}
+
+	@GetMapping("/login_rejected")
+	public String loginRejected(HttpServletResponse response) {
+		response.setStatus(HttpStatus.FORBIDDEN.value());
+		return "error/login_rejected";
 	}
 }

--- a/src/main/java/site/soloforest/soloforest/base/security/AccountAdapter.java
+++ b/src/main/java/site/soloforest/soloforest/base/security/AccountAdapter.java
@@ -7,11 +7,11 @@ import site.soloforest.soloforest.boundedContext.account.entity.Account;
 
 @Getter
 public class AccountAdapter extends User {
-	private Account account;
+	private Long id;
 
 	public AccountAdapter(Account account) {
 		super(account.getUsername(), account.getPassword(), account.getGrantedAuthorities());
 
-		this.account = account;
+		this.id = account.getId();
 	}
 }

--- a/src/main/java/site/soloforest/soloforest/base/security/CustomAuthenticationSuccessHandler.java
+++ b/src/main/java/site/soloforest/soloforest/base/security/CustomAuthenticationSuccessHandler.java
@@ -35,7 +35,7 @@ public class CustomAuthenticationSuccessHandler implements AuthenticationSuccess
 		}
 
 		Account account = accountRepository.findById(
-			((AccountAdapter)authentication.getPrincipal()).getAccount().getId()).orElse(null);
+			((AccountAdapter)authentication.getPrincipal()).getId()).orElse(null);
 		if (account != null && account.getLoginRejectedDeadline() != null &&
 			account.getLoginRejectedDeadline().isAfter(LocalDateTime.now())) {
 			HttpSession session = request.getSession(false);

--- a/src/main/java/site/soloforest/soloforest/base/security/CustomAuthenticationSuccessHandler.java
+++ b/src/main/java/site/soloforest/soloforest/base/security/CustomAuthenticationSuccessHandler.java
@@ -1,0 +1,52 @@
+package site.soloforest.soloforest.base.security;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.security.web.savedrequest.HttpSessionRequestCache;
+import org.springframework.security.web.savedrequest.RequestCache;
+import org.springframework.security.web.savedrequest.SavedRequest;
+import org.springframework.stereotype.Service;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import site.soloforest.soloforest.boundedContext.account.entity.Account;
+import site.soloforest.soloforest.boundedContext.account.repository.AccountRepository;
+
+@Service
+@RequiredArgsConstructor
+public class CustomAuthenticationSuccessHandler implements AuthenticationSuccessHandler {
+	private final AccountRepository accountRepository;
+	private RequestCache requestCache = new HttpSessionRequestCache(); // 로그인페이지 이동 전 요청 저장되어있음
+
+	@Override
+	public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+		Authentication authentication) throws IOException {
+		SavedRequest savedRequest = requestCache.getRequest(request, response);
+		String targetUrl = "/main";
+
+		if (savedRequest != null) {
+			targetUrl = savedRequest.getRedirectUrl();
+		}
+
+		Account account = accountRepository.findById(
+			((AccountAdapter)authentication.getPrincipal()).getAccount().getId()).orElse(null);
+		if (account != null && account.getLoginRejectedDeadline() != null &&
+			account.getLoginRejectedDeadline().isAfter(LocalDateTime.now())) {
+			HttpSession session = request.getSession(false);
+			if (session != null) {
+				session.invalidate();
+			}
+			SecurityContextHolder.clearContext();
+			response.sendRedirect("/error/403");
+		} else {
+			response.sendRedirect(targetUrl);
+		}
+
+	}
+}

--- a/src/main/java/site/soloforest/soloforest/base/security/SecurityConfig.java
+++ b/src/main/java/site/soloforest/soloforest/base/security/SecurityConfig.java
@@ -11,10 +11,15 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
+import lombok.RequiredArgsConstructor;
+
 @Configuration  // 환경설정
 @EnableWebSecurity // 모든 요청 URL이 스프링 시큐리티의 제어를 받도록 만듬
 @EnableMethodSecurity(prePostEnabled = true)  // PreAuthorize 사용하기 위해 반드시 필요
+@RequiredArgsConstructor
 public class SecurityConfig {
+	private final CustomAuthenticationSuccessHandler customAuthenticationSuccessHandler;
+
 	@Bean
 		// 리턴값은 Bean에 등록
 		// SecurityFilterChain 빈을 생성하여 스프링 시큐리티 세부 설정 가능
@@ -23,7 +28,7 @@ public class SecurityConfig {
 			.formLogin(
 				formLogin -> formLogin
 					.loginPage("/account/login")
-					.defaultSuccessUrl("/main")
+					.successHandler(customAuthenticationSuccessHandler)
 					.failureUrl("/account/login?error=true")
 			)
 			.logout(

--- a/src/main/java/site/soloforest/soloforest/base/web/LoginRejectedInterceptor.java
+++ b/src/main/java/site/soloforest/soloforest/base/web/LoginRejectedInterceptor.java
@@ -1,0 +1,48 @@
+package site.soloforest.soloforest.base.web;
+
+import java.time.LocalDateTime;
+
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import site.soloforest.soloforest.base.security.AccountAdapter;
+import site.soloforest.soloforest.boundedContext.account.entity.Account;
+import site.soloforest.soloforest.boundedContext.account.repository.AccountRepository;
+
+@Component
+@RequiredArgsConstructor
+public class LoginRejectedInterceptor implements HandlerInterceptor {
+	private final AccountRepository accountRepository;
+	private final HttpSession session;
+
+	@Override
+	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
+		throws Exception {
+		Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+
+		// 로그인한 사용자인 경우 (principal 객체가 'anonymousUser'일 경우, 비 로그인 상태)
+		if (principal instanceof AccountAdapter) {
+			Account account = accountRepository.findById(((AccountAdapter)principal).getId())
+				.get(); // 현재 로그인한 account id로 최신 엔티티 불러오기
+			// 지금 시간이 로그인 거부 기간 안에 있는지 확인
+			if (account.getLoginRejectedDeadline() != null
+				&& account.getLoginRejectedDeadline().isAfter(LocalDateTime.now())) {
+				if (session != null) {
+					session.invalidate();
+				}
+				session.setAttribute("loginRejectedDeadline", account.getLoginRejectedDeadline());
+				SecurityContextHolder.clearContext(); // 인증 정보 초기화
+				response.sendRedirect("/error/login_rejected"); // 로그인 거부 에러 페이지로 리다이렉트
+
+				return false;
+			}
+		}
+
+		return true;
+	}
+}

--- a/src/main/java/site/soloforest/soloforest/base/web/WebConfig.java
+++ b/src/main/java/site/soloforest/soloforest/base/web/WebConfig.java
@@ -1,0 +1,20 @@
+package site.soloforest.soloforest.base.web;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+	private final LoginRejectedInterceptor loginRejectedInterceptor;
+
+	@Override
+	public void addInterceptors(InterceptorRegistry registry) {
+		registry.addInterceptor(loginRejectedInterceptor)
+			.addPathPatterns("/**")
+			.excludePathPatterns("/error/login_rejected"); // 제재당한 사용자는 무조건 로그인이 풀려야 합니다.
+	}
+}

--- a/src/main/java/site/soloforest/soloforest/boundedContext/account/controller/AccountController.java
+++ b/src/main/java/site/soloforest/soloforest/boundedContext/account/controller/AccountController.java
@@ -87,4 +87,14 @@ public class AccountController {
 
 		return accountService.withdraw(accountAdapter.getAccount(), password, request);
 	}
+
+	@PostMapping("/report/{id}")
+	@PreAuthorize("isAuthenticated()")
+	public ResponseEntity<String> report(@PathVariable Long id,
+		@AuthenticationPrincipal AccountAdapter accountAdapter) {
+		if (accountAdapter.getAccount().getId().equals(id)) {
+			return new ResponseEntity<>("자기 자신을 신고할 수 없습니다.", HttpStatus.BAD_REQUEST);
+		}
+		return accountService.report(id, accountAdapter.getAccount());
+	}
 }

--- a/src/main/java/site/soloforest/soloforest/boundedContext/account/controller/AccountController.java
+++ b/src/main/java/site/soloforest/soloforest/boundedContext/account/controller/AccountController.java
@@ -81,20 +81,20 @@ public class AccountController {
 	@ResponseBody
 	public ResponseEntity<String> withdraw(@PathVariable Long id, @RequestParam("password") String password,
 		@AuthenticationPrincipal AccountAdapter accountAdapter, HttpServletRequest request) {
-		if (!accountAdapter.getAccount().getId().equals(id)) {
+		if (!accountAdapter.getId().equals(id)) {
 			return new ResponseEntity<>("Authentication failed", HttpStatus.UNAUTHORIZED);
 		}
 
-		return accountService.withdraw(accountAdapter.getAccount(), password, request);
+		return accountService.withdraw(accountAdapter.getId(), password, request);
 	}
 
 	@PostMapping("/report/{id}")
 	@PreAuthorize("isAuthenticated()")
 	public ResponseEntity<String> report(@PathVariable Long id,
 		@AuthenticationPrincipal AccountAdapter accountAdapter) {
-		if (accountAdapter.getAccount().getId().equals(id)) {
+		if (accountAdapter.getId().equals(id)) {
 			return new ResponseEntity<>("자기 자신을 신고할 수 없습니다.", HttpStatus.BAD_REQUEST);
 		}
-		return accountService.report(id, accountAdapter.getAccount());
+		return accountService.report(id);
 	}
 }

--- a/src/main/java/site/soloforest/soloforest/boundedContext/account/entity/Account.java
+++ b/src/main/java/site/soloforest/soloforest/boundedContext/account/entity/Account.java
@@ -65,6 +65,7 @@ public class Account {
 	private int authority = 1;
 	@Builder.Default
 	private int reported = 0;
+	private LocalDateTime loginRejectedDeadline;
 	@Builder.Default
 	private boolean deleted = false;
 
@@ -88,6 +89,14 @@ public class Account {
 
 	public void setPassword(String password) {
 		this.password = passwordEncoder.encode(password);
+	}
+
+	public int reportUp() {
+		return ++this.reported;
+	}
+
+	public void loginReject() {
+		this.loginRejectedDeadline = LocalDateTime.now().plusDays(3);
 	}
 
 	public List<? extends GrantedAuthority> getGrantedAuthorities() {

--- a/src/main/java/site/soloforest/soloforest/boundedContext/account/service/AccountService.java
+++ b/src/main/java/site/soloforest/soloforest/boundedContext/account/service/AccountService.java
@@ -210,4 +210,24 @@ public class AccountService {
 
 		SecurityContextHolder.clearContext();
 	}
+
+	public ResponseEntity<String> report(Long targetId, Account account) {
+		Optional<Account> target = accountRepository.findById(targetId);
+		if (target.isEmpty()) {
+			return new ResponseEntity<>("대상을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+		}
+		if (target.get().isDeleted()) {
+			return new ResponseEntity<>("탈퇴한 이용자에 대한 신고입니다.", HttpStatus.BAD_REQUEST);
+		}
+
+		int reported = target.get().reportUp();
+		if ((reported / 3 > 0) && (reported % 3 == 0)) {
+			target.get().loginReject();
+			// target의 session을 끊어줘야 함....
+		}
+
+		accountRepository.save(target.get());
+
+		return new ResponseEntity<>("신고가 완료되었습니다.", HttpStatus.OK);
+	}
 }

--- a/src/main/java/site/soloforest/soloforest/boundedContext/account/service/AccountService.java
+++ b/src/main/java/site/soloforest/soloforest/boundedContext/account/service/AccountService.java
@@ -180,7 +180,8 @@ public class AccountService {
 		return true;
 	}
 
-	public ResponseEntity<String> withdraw(Account account, String password, HttpServletRequest request) {
+	public ResponseEntity<String> withdraw(Long id, String password, HttpServletRequest request) {
+		Account account = accountRepository.findById(id).orElse(null);
 		if (account != null) {
 			if (passwordEncoder.matches(password, account.getPassword())) {
 				account.setUsername(null);
@@ -211,7 +212,7 @@ public class AccountService {
 		SecurityContextHolder.clearContext();
 	}
 
-	public ResponseEntity<String> report(Long targetId, Account account) {
+	public ResponseEntity<String> report(Long targetId) {
 		Optional<Account> target = accountRepository.findById(targetId);
 		if (target.isEmpty()) {
 			return new ResponseEntity<>("대상을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);

--- a/src/main/resources/templates/error/403.html
+++ b/src/main/resources/templates/error/403.html
@@ -1,0 +1,24 @@
+<html layout:decorate="~{home/layout.html}">
+<head>
+    <title>403</title>
+</head>
+
+<body>
+<main layout:fragment="main">
+    <div class="flex justify-center items-center w-full" style="height: calc(100vh - 180px);">
+        <div class="card w-96 bg-neutral text-neutral-content">
+            <div class="card-body items-center text-center">
+                <h2 class="card-title">
+                    <i class="fa-solid fa-circle-exclamation"></i>403 ERROR</h2>
+                <p>권한이 없는 이용자입니다.</p>
+                <div class="card-actions justify-end mt-2">
+                    <a href="/main" role="button" class="btn btn-primary">메인으로</a>
+                    <a href="#" onclick="window.history.back();return false;" role="button" class="btn btn-secondary">
+                        이전 페이지로</a>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>
+</body>
+</html>

--- a/src/main/resources/templates/error/login_rejected.html
+++ b/src/main/resources/templates/error/login_rejected.html
@@ -1,0 +1,25 @@
+<html layout:decorate="~{home/layout.html}">
+<head>
+    <title>Login Rejected</title>
+</head>
+
+<body>
+<main layout:fragment="main">
+    <div class="flex justify-center items-center w-full" style="height: calc(100vh - 180px);">
+        <div class="card w-96 bg-neutral text-neutral-content">
+            <div class="card-body items-center text-center">
+                <h2 class="card-title">
+                    <i class="fa-solid fa-circle-exclamation"></i>Login Rejected</h2>
+                <p>신고로 인해 제재당한 이용자입니다.</p>
+                <p><span th:text="${session.loginRejectedDeadline}"></span><span> 이후에 다시 로그인 해주세요.</span></p>
+                <div class="card-actions justify-end mt-2">
+                    <a href="/main" role="button" class="btn btn-primary">메인으로</a>
+                    <a href="#" onclick="window.history.back();return false;" role="button" class="btn btn-secondary">
+                        이전 페이지로</a>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>
+</body>
+</html>


### PR DESCRIPTION
### ✅ **Summary**

**complete** :
- [x] (난이도 하) 게시글, 댓글에서 신고하기 누르면 바로 controller로 전달
- [x] (난이도 하) 대상 이용자의 reported 횟수 증가 후 3회 넘기는지 판단하여 계정 처분 결정
- [x] Account entity에 ```loginRejectedDeadline``` 칼럼 추가

**note** :

- error 처리 관련
  - base/error에 error controller를 만들었습니다! (redirect로 error 페이지를 보낼 때 사용)
  - 403 error 페이지와 login_rejected 페이지를 새로 만들었습니다!

- **로그인 정지된 사용자의 세션을 어떻게 풀어놓을지** 
  - spring web의 인터셉터를 이용해, 페이지를 이동할 때마다 제재 대상인지 확인하는 로직을 넣었습니다.
  - base/web/WebConfig.java 파일의 ```.excludePathPatterns()```에 주소를 넣으면 체크 대상에서 제외됩니다.(**권장하지 않습니다.**)

- loginRejectedDeadline 칼럼에 적힌 날짜 이후로는 로그인이 되도록 바꾸는 법
  - 로그인할 때 ```loginRejectedDeadline```을 확인(```base/security/CustomAuthenticationSuccessHandler.java```)
 
### ✅ **next plan**
- 신고 create시 event 발생하고 알림 보내기
- id/pw 찾기 구현

- report story(난이도 상) -> **관리자 구현에 필요**
  - 게시글/댓글에서 신고하기 링크 클릭 -> 신고 페이지 이동 및 사유 입력 -> 대상 이용자의 신고횟수 증가 및 관리자에게 이벤트 발생(알림) -> 관리자가 직접 정지/탈퇴처분 결정 -> 이벤트 발생(알림)