### PR TITLE
feat : 게시글, 댓글 통합

### DIFF
--- a/src/main/java/site/soloforest/soloforest/base/initData/NotProd.java
+++ b/src/main/java/site/soloforest/soloforest/base/initData/NotProd.java
@@ -108,7 +108,7 @@ public class NotProd {
 				Comment replyComment1 = commentService.createReplyComment("신고하세요", false, accountAdmin1, community1,
 					comment3);
 				Comment replyComment2 = commentService.createReplyComment("네 맞습니다!", false, accounts.get(2),
-					community1, comment10);
+					community1, comment3);
 				Comment replyComment3 = commentService.createReplyComment("가시죠!!", false, accounts.get(1),
 					program1, comment8);
 				Comment replyComment4 = commentService.createReplyComment("가자구!", false, accounts.get(1),
@@ -116,11 +116,13 @@ public class NotProd {
 
 				Comment comment17 = commentService.create("부모 댓글 연쇄 삭제 테스트용", false, accountAdmin1, community1);
 				comment17.deleteParent();
-				Comment replyComment5 = commentService.createReplyComment("이녀석 삭제되면 위에 녀석 삭제되어야 함", false, accountAdmin1,
+				Comment replyComment5 = commentService.createReplyComment("이녀석 삭제되면 위에 녀석 삭제되어야 함", false,
+					accountAdmin1,
 					community1, comment17);
 
 				// 페이징 테스트용 댓글
-				IntStream.rangeClosed(5, 100).forEach(n -> commentService.create("테스트 데이터 %d".formatted(n), false, accountAdmin1, community1));
+				IntStream.rangeClosed(5, 100)
+					.forEach(n -> commentService.create("테스트 데이터 %d".formatted(n), false, accountAdmin1, community1));
 			}
 		};
 	}

--- a/src/main/java/site/soloforest/soloforest/base/rq/Rq.java
+++ b/src/main/java/site/soloforest/soloforest/base/rq/Rq.java
@@ -2,6 +2,7 @@ package site.soloforest.soloforest.base.rq;
 
 import java.util.Date;
 
+import org.springframework.data.domain.Page;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.User;
@@ -16,6 +17,8 @@ import site.soloforest.soloforest.boundedContext.account.entity.Account;
 import site.soloforest.soloforest.boundedContext.account.service.AccountService;
 import site.soloforest.soloforest.boundedContext.article.entity.Article;
 import site.soloforest.soloforest.boundedContext.article.service.ArticleService;
+import site.soloforest.soloforest.boundedContext.comment.entity.Comment;
+import site.soloforest.soloforest.boundedContext.comment.service.CommentService;
 import site.soloforest.soloforest.standard.util.Ut;
 
 @Component
@@ -28,15 +31,16 @@ public class Rq {
 	private final HttpSession session;
 	private final User user;
 	private Account account = null; // 레이지 로딩, 처음부터 넣지 않고, 요청이 들어올 때 넣는다.
+	private final CommentService commentService;
 
-
-
-	public Rq(AccountService accountService, ArticleService articleService, HttpServletRequest req, HttpServletResponse resp, HttpSession session) {
+	public Rq(AccountService accountService, ArticleService articleService, HttpServletRequest req,
+		HttpServletResponse resp, HttpSession session, CommentService commentService) {
 		this.accountService = accountService;
 		this.articleService = articleService;
 		this.req = req;
 		this.resp = resp;
 		this.session = session;
+		this.commentService = commentService;
 
 		// 현재 로그인한 회원의 인증정보를 가져옴
 		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
@@ -70,12 +74,10 @@ public class Rq {
 
 		return account;
 	}
+
 	public Article getArticle(Long articleId) {
 		return articleService.getArticle(articleId);
 	}
-
-
-
 
 	public String historyBack(String msg) {
 		String referer = req.getHeader("referer");
@@ -112,8 +114,13 @@ public class Rq {
 	}
 
 	public boolean isAdmin() {
-		if (isLogout()) return false;
+		if (isLogout())
+			return false;
 
 		return getAccount().isAdmin();
+	}
+
+	public Page<Comment> getPageByArticle(int page, Article article) {
+		return commentService.getCommentPage(page, article);
 	}
 }

--- a/src/main/java/site/soloforest/soloforest/boundedContext/article/controller/ShareController.java
+++ b/src/main/java/site/soloforest/soloforest/boundedContext/article/controller/ShareController.java
@@ -22,6 +22,7 @@ import site.soloforest.soloforest.base.rq.Rq;
 import site.soloforest.soloforest.base.rsData.RsData;
 import site.soloforest.soloforest.boundedContext.article.entity.Share;
 import site.soloforest.soloforest.boundedContext.article.service.ShareService;
+import site.soloforest.soloforest.boundedContext.comment.entity.Comment;
 
 @Controller
 @RequestMapping("/article/share")
@@ -79,7 +80,7 @@ public class ShareController {
 	}
 
 	@GetMapping("/detail/{id}")
-	public String detail(@PathVariable Long id, Model model) {
+	public String detail(@PathVariable Long id, Model model, @RequestParam(defaultValue = "0") int page) {
 		Optional<Share> share = shareService.findById(id);
 
 		if (share.isEmpty()) {
@@ -87,13 +88,17 @@ public class ShareController {
 		}
 
 		shareService.modifyViewed(share.get());
-		model.addAttribute("share", share.get());
+		model.addAttribute("article", share.get());
 
 		boolean like = shareService.findLike(share.get(), rq.getAccount());
 		model.addAttribute("like", like);
 
 		boolean bookmark = shareService.findBookmark(share.get(), rq.getAccount());
 		model.addAttribute("bookmark", bookmark);
+
+		Page<Comment> paging = rq.getPageByArticle(page, share.get());
+
+		model.addAttribute("paging", paging);
 
 		return "article/share/detail";
 	}

--- a/src/main/java/site/soloforest/soloforest/boundedContext/comment/controller/CommentController.java
+++ b/src/main/java/site/soloforest/soloforest/boundedContext/comment/controller/CommentController.java
@@ -9,7 +9,6 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.server.ResponseStatusException;
 
 import lombok.RequiredArgsConstructor;
@@ -36,7 +35,6 @@ public class CommentController {
 
 	@PreAuthorize("isAuthenticated()")
 	@PostMapping("/create")
-	@ResponseBody
 	public String create(Model model, @ModelAttribute CommentDTO commentDTO,
 		@RequestParam(defaultValue = "0") int page) {
 		Article article = rq.getArticle(commentDTO.getArticleId());
@@ -50,7 +48,15 @@ public class CommentController {
 		Page<Comment> paging = commentService.getCommentPage(page, article);
 		model.addAttribute("paging", paging);
 
-		return (comment.getId() - 1 + "");
+		int lastPage = commentService.getLastPageNumber(article);
+
+		if (article.getBoardNumber() < 2) {
+			return "redirect:/article/share/detail/" + article.getId() + "?page=" + lastPage + "#" + "comment_"
+				+ comment.getId();
+		}
+
+		return "redirect:/article/group/detail/" + article.getId() + "?page=" + lastPage + "#" + "comment_"
+			+ comment.getId();
 	}
 
 	@PreAuthorize("isAuthenticated()")

--- a/src/main/java/site/soloforest/soloforest/boundedContext/comment/controller/CommentController.java
+++ b/src/main/java/site/soloforest/soloforest/boundedContext/comment/controller/CommentController.java
@@ -5,7 +5,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -35,51 +34,41 @@ public class CommentController {
 	// private static final Logger logger = LoggerFactory.getLogger(CommentController.class);
 	// 	logger.info("showComment 메서드 호출");
 
-	// 삭제 예정(댓글 자체는 게시글 조회시 자동으로 나오게)
-	@GetMapping("")
-	public String showComment(Model model, @RequestParam(defaultValue = "0") int page) {
-
-		// TODO : 게시글과 합칠때는 실제 articleID를 받아서 가져오기
-		Article article = rq.getArticle(1L);
-		Page<Comment> paging = commentService.getCommentPage(page, article);
-
-		model.addAttribute("article", article);
-		model.addAttribute("paging", paging);
-
-		return "comment/comment";
-	}
-
 	@PreAuthorize("isAuthenticated()")
 	@PostMapping("/create")
 	@ResponseBody
-	public String create(Model model ,@ModelAttribute CommentDTO commentDTO, @RequestParam(defaultValue = "0") int page) {
+	public String create(Model model, @ModelAttribute CommentDTO commentDTO,
+		@RequestParam(defaultValue = "0") int page) {
 		Article article = rq.getArticle(commentDTO.getArticleId());
 		Account account = rq.getAccount();
 		// 부모댓글 생성
-		Comment comment = 	commentService.create(commentDTO.getCommentContents(), commentDTO.getSecret(), account, article);
+		Comment comment = commentService.create(commentDTO.getCommentContents(), commentDTO.getSecret(), account,
+			article);
 
 		model.addAttribute("article", article);
 
 		Page<Comment> paging = commentService.getCommentPage(page, article);
 		model.addAttribute("paging", paging);
 
-		return (comment.getId() +"");
+		return (comment.getId() - 1 + "");
 	}
 
 	@PreAuthorize("isAuthenticated()")
 	@PostMapping("/reply/create")
-	public String replyCreate(Model model ,@ModelAttribute CommentDTO commentDTO, @RequestParam(defaultValue = "0") int page) {
+	public String replyCreate(Model model, @ModelAttribute CommentDTO commentDTO,
+		@RequestParam(defaultValue = "0") int page) {
 		Article article = rq.getArticle(commentDTO.getArticleId());
 		Account account = rq.getAccount();
 
-			// 부모 댓글 찾아오기
-			Comment parent = commentService.getComment(commentDTO.getParentId());
-			// ToDo : RsData 도입 고려
-			if(parent == null) {
-				throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "해당 댓글을 찾을 수 없습니다");
-			}
-			// 자식 댓글 생성
-			commentService.createReplyComment(commentDTO.getCommentContents(), commentDTO.getSecret(), account, article, parent);
+		// 부모 댓글 찾아오기
+		Comment parent = commentService.getComment(commentDTO.getParentId());
+		// ToDo : RsData 도입 고려
+		if (parent == null) {
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "해당 댓글을 찾을 수 없습니다");
+		}
+		// 자식 댓글 생성
+		commentService.createReplyComment(commentDTO.getCommentContents(), commentDTO.getSecret(), account, article,
+			parent);
 
 		model.addAttribute("article", article);
 
@@ -97,11 +86,11 @@ public class CommentController {
 		Account account = rq.getAccount();
 
 		// ToDo : RsData 고민
-		 if(!(account.isAdmin()) && (account.getId() != commentDTO.getCommentWriter())) {
-			 throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "수정권한이 없습니다");
-		 }
+		if (!(account.isAdmin()) && (account.getId() != commentDTO.getCommentWriter())) {
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "수정권한이 없습니다");
+		}
 
-		 // 대댓글(답글)도 id로 찾을 수 있음(댓글과 동일 객체 사용이 가능하니 하나의 메서드로 처리 가능)
+		// 대댓글(답글)도 id로 찾을 수 있음(댓글과 동일 객체 사용이 가능하니 하나의 메서드로 처리 가능)
 		Comment comment = commentService.getComment(commentDTO.getId());
 
 		// 댓글 내용, 비밀 댓글 여부만 수정 할테니 해당 값 넘기기
@@ -123,7 +112,7 @@ public class CommentController {
 
 		// ToDo : RsData 고려
 		// 관리자가 아니거나 현재 로그인한 사용자가 작성한 댓글이 아니면 삭제 불가
-		if(!(account.isAdmin()) && (account.getId() != commentDTO.getCommentWriter())) {
+		if (!(account.isAdmin()) && (account.getId() != commentDTO.getCommentWriter())) {
 			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "삭제 권한이 없습니다");
 		}
 
@@ -132,15 +121,15 @@ public class CommentController {
 		// 이 작업은 꼭 해줘야 대댓글 리스트도 수정된다!
 		// 부모 댓글이 삭제 상태이며, 부모의 자식이 1개(삭제하려는 자기 뿐)일 경우 연관관계 유지 시켜줘야
 		// 같이 삭제되니 연관관계 유지
-		if(comment.getParent() != null && comment.getParent().isDeleted() && comment.getParent().getChildren().size() ==1)
-		{
+		if (comment.getParent() != null && comment.getParent().isDeleted()
+			&& comment.getParent().getChildren().size() == 1) {
 		}
 		// 댓글 자체가 삭제 상태건 아니건, 자식이 2개 이상 있는 상황이라면 그냥 대댓글만 삭제하면 되니까 해당 댓글 연관관계만 끊어주기
-		else if(comment.getParent() != null && comment.getParent().getChildren().size() > 1) {
+		else if (comment.getParent() != null && comment.getParent().getChildren().size() > 1) {
 			comment.getParent().getChildren().remove(comment);
 		}
 		// 부모가 있고, 삭제 상태가 아니라면 대댓글만 삭제 => Ajax 비동기 리스트화를 위해 리스트에서 명시적 삭제
-		else if(comment.getParent() !=null && !comment.isDeleted()) {
+		else if (comment.getParent() != null && !comment.isDeleted()) {
 			comment.getParent().getChildren().remove(comment);
 		}
 

--- a/src/main/java/site/soloforest/soloforest/boundedContext/comment/repository/CommentRepository.java
+++ b/src/main/java/site/soloforest/soloforest/boundedContext/comment/repository/CommentRepository.java
@@ -10,11 +10,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import site.soloforest.soloforest.boundedContext.article.entity.Article;
 import site.soloforest.soloforest.boundedContext.comment.entity.Comment;
 
-
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 	Optional<Comment> findById(Long id);
 
 	List<Comment> findAllByArticle(Article article);
 
 	Page<Comment> findAllByArticle(Article article, Pageable pageable);
+
+	int countByArticle(Article article);
 }

--- a/src/main/java/site/soloforest/soloforest/boundedContext/comment/service/CommentService.java
+++ b/src/main/java/site/soloforest/soloforest/boundedContext/comment/service/CommentService.java
@@ -47,7 +47,8 @@ public class CommentService {
 	}
 
 	@Transactional
-	public Comment createReplyComment(String content, boolean secret, Account account, Article article, Comment parentComment) {
+	public Comment createReplyComment(String content, boolean secret, Account account, Article article,
+		Comment parentComment) {
 		Comment newComment = Comment.builder()
 			.content(content)
 			.writer(account)
@@ -64,7 +65,6 @@ public class CommentService {
 
 		return newComment;
 	}
-
 
 	// 테스트용
 	public Comment getComment(Long commentId) {
@@ -92,8 +92,7 @@ public class CommentService {
 		if (comment.getChildren().size() != 0) {
 			// 자식이 있으면 삭제 상태만 변경
 			comment.deleteParent();
-		}
-		else { // 자식이 없다 -> 대댓글이 없다 -> 객체 그냥 삭제해도 된다.
+		} else { // 자식이 없다 -> 대댓글이 없다 -> 객체 그냥 삭제해도 된다.
 			// 삭제 가능한 조상 댓글을 구해서 삭제
 			// ex) 할아버지 - 아버지 - 대댓글, 3자라 했을 때 대댓글 입장에서 자식이 없으니 삭제 가능
 			// => 삭제하면 아버지도 삭제 가능 => 할아버지도 삭제 가능하니 이런식으로 조상 찾기 메서드
@@ -121,7 +120,7 @@ public class CommentService {
 
 	// 댓글 조회
 	public Comment findById(Long id) {
-			return commentRepository.findById(id).orElse(null);
+		return commentRepository.findById(id).orElse(null);
 	}
 
 	public List<Comment> getCommentList(Article article) {
@@ -135,6 +134,10 @@ public class CommentService {
 		return commentRepository.findAllByArticle(article, pageable);
 	}
 
-
-
+	public int getLastPageNumber(Article article) {
+		int commentCount = commentRepository.countByArticle(article);
+		int pageSize = 10; // 페이지 당 댓글 수 (조정 가능)
+		int lastPageNumber = (int)Math.ceil((double)commentCount / pageSize);
+		return lastPageNumber - 1;
+	}
 }

--- a/src/main/resources/application-secret.yml.template
+++ b/src/main/resources/application-secret.yml.template
@@ -1,0 +1,7 @@
+spring:
+  datasource:
+    username: your
+    password: your
+  mail:
+    username: your@email.com
+    password: your

--- a/src/main/resources/application-secret.yml.template
+++ b/src/main/resources/application-secret.yml.template
@@ -1,7 +1,0 @@
-spring:
-  datasource:
-    username: your
-    password: your
-  mail:
-    username: your@email.com
-    password: your

--- a/src/main/resources/templates/article/share/detail.html
+++ b/src/main/resources/templates/article/share/detail.html
@@ -13,19 +13,17 @@
             </h1>
             <span class="ml-4 h-4 w-px bg-black"></span>
         </div>
-        <!-- 검색 시작-->
-        <div class="ml-auto mr-3 flex gap-4" th:if="${#authentication.getPrincipal() != 'anonymousUser'}">
+        <div class="ml-auto mr-3 flex gap-4" th:if="${@rq.login}">
             <a th:href="@{|/article/share/modify/${article.id}|}" role="button"
                class="btn btn-outline btn-primary btn-sm"
-               th:if="${article.account != null and #authentication.getPrincipal().getUsername() == article.account.username}">수정</a>
+               th:if="${article.account != null and (@rq.account.username == article.account.username)}">수정</a>
             <form th:action="@{|/article/share/${article.boardType}/delete/${article.id}|}" method="post">
                 <button type="submit" class="btn btn-outline btn-error btn-sm"
-                        th:if="${article.account != null and #authentication.getPrincipal().getUsername() == article.account.username}"
+                        th:if="${article.account != null and ((@rq.account.username == article.account.username) or (@rq.account.admin))}"
                         onclick="return confirm('이 글을 삭제하시겠습니까?');">삭제
                 </button>
             </form>
         </div>
-        <!-- 검색 끝 -->
     </div>
     <div class="container mx-auto">
         <div class="bg-white p-6 rounded-lg shadow-lg mb-6"
@@ -46,7 +44,7 @@
                 <span class="gap-1" th:text="${article.viewed}"></span>
                 <!-- 즐겨찾기 시작-->
                 <button id="bookmark" class="mr-10" style="float: right; display: inline-block;"
-                        th:if="${@rq.isLogin()}" th:value="${bookmark} ? 1 : 0 ">
+                        th:if="${@rq.login}" th:value="${bookmark} ? 1 : 0 ">
                     <i id="bookmark_icon"></i>
                 </button>
                 <!-- 즐겨찾기 끝-->
@@ -57,12 +55,12 @@
             </div>
             <div class="mb-6 ml-6">
                 <!-- 좋아요 시작-->
-                <input type="hidden" id="shareId" th:value="${article.getId()}">
-                <input type="hidden" id="accountId" th:value="${@rq.isLogin()} ? ${@rq.getAccount().getId()} : null">
+                <input type="hidden" id="shareId" th:value="${article.id}">
+                <input type="hidden" id="accountId" th:value="${@rq.login} ? ${@rq.account.id} : null">
                 <button id="like_login" th:if="${@rq.isLogout()}">
                     <i class="fa-regular fa-thumbs-up"></i>
                 </button>
-                <button id="like" th:value="${like} ? 1 : 0" th:if="${@rq.isLogin()}">
+                <button id="like" th:value="${like} ? 1 : 0" th:if="${@rq.login}">
                     <i id="like_icon"></i>
                 </button>
                 <input type="hidden" id="share_likes" th:value="${article.likes}">

--- a/src/main/resources/templates/article/share/detail.html
+++ b/src/main/resources/templates/article/share/detail.html
@@ -2,47 +2,49 @@
 <head>
     <meta name="_csrf_header" th:content="${_csrf.headerName}">
     <meta name="_csrf" th:content="${_csrf.token}">
-    <title th:text="${share.subject}"></title>
+    <title th:text="${article.subject}"></title>
 </head>
 
 <body>
 <main layout:fragment="main">
     <div class="flex items-center justify-center mt-4 mb-3 relative">
         <div class="mr-auto flex justify-center items-center min-w-[150px]">
-            <h1 class="font-semibold" th:text="${share.boardNumber == 0} ? '커뮤니티 게시판' : '프로그램 게시판'">
+            <h1 class="font-semibold" th:text="${article.boardNumber == 0} ? '커뮤니티 게시판' : '프로그램 게시판'">
             </h1>
             <span class="ml-4 h-4 w-px bg-black"></span>
         </div>
+        <!-- 검색 시작-->
         <div class="ml-auto mr-3 flex gap-4" th:if="${#authentication.getPrincipal() != 'anonymousUser'}">
-            <a th:href="@{|/article/share/modify/${share.id}|}" role="button"
+            <a th:href="@{|/article/share/modify/${article.id}|}" role="button"
                class="btn btn-outline btn-primary btn-sm"
-               th:if="${share.account != null and #authentication.getPrincipal().getUsername() == share.account.username}">수정</a>
-            <form th:action="@{|/article/share/${share.getBoardType()}/delete/${share.id}|}" method="post">
+               th:if="${article.account != null and #authentication.getPrincipal().getUsername() == article.account.username}">수정</a>
+            <form th:action="@{|/article/share/${article.boardType}/delete/${article.id}|}" method="post">
                 <button type="submit" class="btn btn-outline btn-error btn-sm"
-                        th:if="${share.account != null and #authentication.getPrincipal().getUsername() == share.account.username}"
+                        th:if="${article.account != null and #authentication.getPrincipal().getUsername() == article.account.username}"
                         onclick="return confirm('이 글을 삭제하시겠습니까?');">삭제
                 </button>
             </form>
         </div>
+        <!-- 검색 끝 -->
     </div>
     <div class="container mx-auto">
         <div class="bg-white p-6 rounded-lg shadow-lg mb-6"
              style="min-height: 600px; max-height: auto; overflow: auto;">
-            <h1 class="text-3xl font-semibold ml-2" th:text="${share.subject}"></h1>
+            <h1 class="text-3xl font-semibold ml-2" th:text="${article.subject}"></h1>
             <div class="mb-3 ml-3">
                 <ul class="menu menu-horizontal menu-compact">
                     <li tabindex="0">
                         <span class="font-bold text-primary"
-                              th:text="${share.account.nickname}"></span>
+                              th:text="${article.account.nickname}"></span>
                         <ul class="bg-white">
                             <li><a>신고하기</a></li>
                         </ul>
                     </li>
                 </ul>
-                <span th:text="${#temporals.format(share.createDate, 'MM.dd')}"></span>
+                <span th:text="${#temporals.format(article.createDate, 'MM.dd')}"></span>
                 <i class="ml-2 fa-solid fa-eye"></i>
-                <span class="gap-1" th:text="${share.viewed}"></span>
-                <!-- 즐겨찾기 -->
+                <span class="gap-1" th:text="${article.viewed}"></span>
+                <!-- 즐겨찾기 시작-->
                 <button id="bookmark" class="mr-10" style="float: right; display: inline-block;"
                         th:if="${@rq.isLogin()}" th:value="${bookmark} ? 1 : 0 ">
                     <i id="bookmark_icon"></i>
@@ -51,11 +53,11 @@
             </div>
             <hr class="mb-8" style="border: none; border-top: 1px solid;">
             <div class="mb-5 ml-5" style="height: 300px; max-height: auto; overflow: auto;">
-                <span class="text-xl" th:text="${share.content}"></span>
+                <span class="text-xl" th:text="${article.content}"></span>
             </div>
             <div class="mb-6 ml-6">
-                <!-- 좋아요 -->
-                <input type="hidden" id="shareId" th:value="${share.getId()}">
+                <!-- 좋아요 시작-->
+                <input type="hidden" id="shareId" th:value="${article.getId()}">
                 <input type="hidden" id="accountId" th:value="${@rq.isLogin()} ? ${@rq.getAccount().getId()} : null">
                 <button id="like_login" th:if="${@rq.isLogout()}">
                     <i class="fa-regular fa-thumbs-up"></i>
@@ -63,14 +65,21 @@
                 <button id="like" th:value="${like} ? 1 : 0" th:if="${@rq.isLogin()}">
                     <i id="like_icon"></i>
                 </button>
-                <input type="hidden" id="share_likes" th:value="${share.likes}">
-                <span id="like_count" class="gap-1" th:text="${share.likes}"></span>
+                <input type="hidden" id="share_likes" th:value="${article.likes}">
+                <span id="like_count" class="gap-1" th:text="${article.likes}"></span>
                 <!-- 좋아요 끝 -->
                 <i class="fa-regular fa-comment ml-3"></i>
-                <span class="gap-1" th:text="${share.comments.size()}"></span>
+                <span class="gap-1" th:text="${article.comments.size()}"></span>
             </div>
             <hr class="mb-8" style="border: none; border-top: 1px solid;">
         </div>
+        <!-- 댓글 시작 -->
+        <div class="comments">
+            <!-- comment.html Include -->
+            <div layout:include="comment/comment.html"></div>
+        </div>
+
+        <!-- 댓글 끝 -->
     </div>
     <script>
         document.getElementById("like_login").onclick = function () {
@@ -84,7 +93,6 @@
         const shareId = $("#shareId").val();
 
         const like = document.getElementById("like").value;
-        const like_count = document.getElementById("like_count").value;
         const like_icon = document.getElementById("like_icon");
         const bookmark = document.getElementById("bookmark").value;
         const bookmark_icon = document.getElementById("bookmark_icon");

--- a/src/main/resources/templates/comment/comment.html
+++ b/src/main/resources/templates/comment/comment.html
@@ -1,23 +1,28 @@
 <main>
     <!-- 댓글 작성 부분 -->
     <div id="write">
-        <textarea th:if="${@rq.login}" placeholder="댓글을 입력해주세요." id="commentContents" columns="4" class="border border-gray-300 rounded-lg textarea-lg w-full
+        <form th:action="@{|/comment/create|}" method="POST">
+            <input type="hidden" name="articleId" th:value="${article.id}">
+            <input type="hidden" name="page" th:value="${paging.totalPages-1}">
+            <textarea th:if="${@rq.login}" name="commentContents" placeholder="댓글을 입력해주세요." id="commentContents"
+                      columns="4" class="border border-gray-300 rounded-lg textarea-lg w-full
         focus:outline-none focus:ring-2 focus:ring-blue-400"></textarea>
-        <textarea th:unless="${@rq.login}" disabled placeholder="로그인 후 댓글 작성이 가능합니다." columns="4" class="border border-gray-300 rounded-lg textarea-lg w-full
+            <textarea th:unless="${@rq.login}" disabled placeholder="로그인 후 댓글 작성이 가능합니다." columns="4" class="border border-gray-300 rounded-lg textarea-lg w-full
         focus:outline-none focus:ring-2 focus:ring-blue-400"></textarea>
-        <label class="label cursor-pointer flex space-x-2">
-            <span class="label-text">비밀 댓글</span>
-            <input type="checkbox" id="secret" class="mr-5"/>
-        </label>
-        <button id="comment-write-btn" onclick="commentWrite()" class="bg-blue-500 text-white py-2
+            <label class="label cursor-pointer flex space-x-2">
+                <span class="label-text">비밀 댓글</span>
+                <input type="checkbox" name="secret" id="secret"/>
+            </label>
+            <button inid="comment-write-btn" class="bg-blue-500 text-white py-2
         px-4 rounded-lg hover:bg-blue-600">
-            <span>댓글작성</span>
-        </button>
+                <span>댓글작성</span>
+            </button>
+        </form>
     </div>
     <!-- 댓글 출력 부분, 일단 페이지 접속 했을때 보여지게!-->
     <div id="comment-list">
         <ul class="space-y-4">
-            <li th:each="comment, commentIndex : ${paging}" th:if="${comment.parent == null}">
+            <li th:each="comment : ${paging}" th:if="${comment.parent == null}">
                 <div class="card bg-white border p-4 rounded-lg shadow-lg">
                     <a th:id="|comment_${comment.id}|"></a>
                     <p class="text-lg font-bold" th:if="${!comment.deleted and !comment.secret}">
@@ -26,9 +31,6 @@
                     <p class="text-lg font-bold"
                        th:if="${comment.secret and ((comment.writer.username == @rq.account.username) or (article.account.username == @rq.account.username) or @rq.account.admin)}">
                         [[${comment.content}]]</p>
-                    <p class="text-gray-200"
-                       th:if="${comment.secret and ! ((comment.writer.username == @rq.account.username) or (article.account.username == @rq.account.username) or @rq.account.admin)}">
-                        비밀 댓글로 댓글 작성자, 게시글 관리자만 볼 수 있습니다.</p>
                     <ul class="menu menu-horizontal bg-base-100">
                         <li tabindex="0">
                             <span>작성자 : [[${comment.writer.username}]] </span>
@@ -218,11 +220,9 @@
     <!-- 스크립트는 main 태그 안족에, 타임리프 레이아웃에 의해 body 밖은 무시됨-->
 
     <script th:inline="javascript">
-        const currentPage = [[${paging.number}]];
         // 댓글 작성
         const commentWrite = () => {
-            const secret = document.getElementById("secret");
-            const secretValue = secret.checked ? true : false;
+            const secretValue = document.getElementById("secret").checked ? true : false;
             const contents = document.getElementById("commentContents").value.trim();
             const articleId = [[${article.id}]];
             const lastPage = [[${paging.totalPages}]] - 1;
@@ -253,14 +253,22 @@
                 success: function (response) {
                     const secret = document.getElementById("secret");
                     const contents = document.getElementById("commentContents");
-                    const newUrl = "?page=" + lastPage + "#comment_" + response;
+                    const lastCommentId = "comment_" + ([[${#lists.size(article.comments)}]] - 1);
+                    const newComment = document.getElementById(lastCommentId);
+                    const newUrl = "?page=" + lastPage + "#comment_" + lastCommentId;
 
                     // Reset comment form
                     contents.value = "";
                     secret.checked = false;
 
-                    // Refresh the page
+                    // Refresh the page with anchor
                     window.location.href = newUrl;
+
+                    // Wait for a short delay before scrolling to the new comment
+                    setTimeout(function () {
+                        // Scroll to the new comment
+                        newComment.scrollIntoView();
+                    }, 3000); // Adjust the delay as needed
 
                     toastNotice('댓글이 작성되었습니다');
                 },
@@ -353,6 +361,7 @@
             const secretValue = replySecret.checked ? true : false;
             const contents = document.getElementById("replyCommentContents-" + commentIndex).value.trim();
             const articleId = [[${article.id}]];
+            const currentPage = [[${paging.number}]];
 
             if (contents.length == 0) {
                 toastWarning('답글을 입력해주세요');
@@ -397,6 +406,7 @@
             const contents = document.getElementById("modify-comment-contents-" + commentIndex).value.trim();
             ; // 내용
             const articleId = [[${article.id}]];
+            const currentPage = [[${paging.number}]];
 
             if (contents.length == 0) {
                 toastWarning('댓글을 입력해주세요');
@@ -443,7 +453,7 @@
             const articleId = [[${article.id}]];
             const commentId = document.getElementById("comment-" + commentIndex).value; // 댓글번호
             const writerId = document.getElementById("writer-" + commentIndex).value; // 작성자 ID
-
+            const currentPage = [[${paging.number}]];
             var header = $("meta[name='_csrf_header']").attr('content');
             var token = $("meta[name='_csrf']").attr('content');
 
@@ -480,7 +490,7 @@
             const articleId = [[${article.id}]];
             const writerId = document.getElementById("modify-reply-writer-" + childIndex).value; // 작성자 ID
             const commentId = document.getElementById("modify-reply-comment-" + childIndex).value; // 댓글번호
-
+            const currentPage = [[${paging.number}]];
             if (contents.length == 0) {
                 toastWarning('댓글을 입력해주세요');
                 return;

--- a/src/main/resources/templates/comment/comment.html
+++ b/src/main/resources/templates/comment/comment.html
@@ -1,14 +1,4 @@
-<html layout:decorate="~{home/layout.html}">
-<head>
-    <title>댓글테스트</title>
-    <!-- jQuery CDN -->
-    <script src="https://code.jquery.com/jquery-3.7.0.min.js"
-            integrity="sha256-2Pmvv0kuTBOenSvLm6bvfBSSHrUJ+3A7x6P5Ebd07/g=" crossorigin="anonymous"></script>
-    <meta name="_csrf_header" th:content="${_csrf.headerName}">
-    <meta name="_csrf" th:content="${_csrf.token}">
-</head>
-<body>
-<main layout:fragment="main">
+<main>
     <!-- 댓글 작성 부분 -->
     <div id="write">
         <textarea th:if="${@rq.login}" placeholder="댓글을 입력해주세요." id="commentContents" columns="4" class="border border-gray-300 rounded-lg textarea-lg w-full
@@ -24,13 +14,12 @@
             <span>댓글작성</span>
         </button>
     </div>
-
     <!-- 댓글 출력 부분, 일단 페이지 접속 했을때 보여지게!-->
     <div id="comment-list">
         <ul class="space-y-4">
             <li th:each="comment, commentIndex : ${paging}" th:if="${comment.parent == null}">
                 <div class="card bg-white border p-4 rounded-lg shadow-lg">
-                    <a th:id="|comment_${comment.id}|" ></a>
+                    <a th:id="|comment_${comment.id}|"></a>
                     <p class="text-lg font-bold" th:if="${!comment.deleted and !comment.secret}">
                         [[${comment.content}]]</p>
                     <p class="text-gray-200" th:if="${comment.deleted}"> 삭제된 댓글입니다.</p>
@@ -203,7 +192,7 @@
         <div class="btn-group flex justify-center" th:if="${!paging.isEmpty()}">
             <div class="btn" th:classappend="${paging.number == 0} ? 'btn-disabled' : ''"
                  th:attr="onclick='window.location.href=\'?page=0#comment-list\''">
-                    &laquo;
+                &laquo;
             </div>
             <div th:attr="onclick='window.location.href=\'?page=' + (${paging.number - 1}) + '#comment-list\''"
                  class="btn" th:classappend="${!paging.hasPrevious} ? 'btn-disabled' : ''">
@@ -213,15 +202,15 @@
                  th:classappend="${paging.number == page} ? 'btn-active' : ''"
                  th:if="${page >= paging.number - 5 and page <= paging.number + 5}"
                  th:attr="onclick='window.location.href=\'?page=' + (${page}) + '#comment-list\''"
-            th:text="${page}">
+                 th:text="${page}">
             </div>
             <div class="btn" th:classappend="${!paging.hasNext} ? 'btn-disabled' :''"
                  th:attr="onclick='window.location.href=\'?page=' + (${paging.number + 1}) + '#comment-list\''">
-                    다음
+                다음
             </div>
             <div th:attr="onclick='window.location.href=\'?page=' + (${paging.totalPages - 1}) + '#comment-list\''"
                  class="btn" th:classappend="${paging.number == paging.totalPages - 1} ? 'btn-disabled' : ''">
-                    &raquo;
+                &raquo;
             </div>
         </div>
     </div>
@@ -259,11 +248,20 @@
                     "articleId": articleId,
                     "secret": secretValue,
                     "commentContents": contents,
-                    "page" : lastPage
+                    "page": lastPage
                 },
                 success: function (response) {
-                    const newUrl = "/comment" + "?page=" + lastPage + "#comment_" + response ;
+                    const secret = document.getElementById("secret");
+                    const contents = document.getElementById("commentContents");
+                    const newUrl = "?page=" + lastPage + "#comment_" + response;
+
+                    // Reset comment form
+                    contents.value = "";
+                    secret.checked = false;
+
+                    // Refresh the page
                     window.location.href = newUrl;
+
                     toastNotice('댓글이 작성되었습니다');
                 },
                 error: function (err) {
@@ -381,7 +379,7 @@
                     "secret": secretValue,
                     "commentContents": contents,
                     "parentId": parentId,
-                    "page" : currentPage
+                    "page": currentPage
                 },
                 success: function (fragment) {
                     $('#comment-list').replaceWith(fragment);
@@ -428,7 +426,7 @@
                     "commentContents": contents,
                     "commentWriter": writerId,
                     "id": commentId,
-                    "page" : currentPage
+                    "page": currentPage
                 },
                 success: function (fragment) {
                     $('#comment-list').replaceWith(fragment);
@@ -461,7 +459,7 @@
                     "articleId": articleId,
                     "commentWriter": writerId,
                     "id": commentId,
-                    "page" : currentPage
+                    "page": currentPage
                 },
                 success: function (fragment) {
                     $('#comment-list').replaceWith(fragment);
@@ -508,7 +506,7 @@
                     "commentContents": contents,
                     "commentWriter": writerId,
                     "id": commentId,
-                    "page" : currentPage
+                    "page": currentPage
                 },
                 success: function (fragment) {
                     $('#comment-list').replaceWith(fragment);
@@ -554,6 +552,3 @@
         }
     </script>
 </main>
-</body>
-
-</html>


### PR DESCRIPTION
### ✅ **Summary**
- **complete** :
  - [x] ShareController에 comment 페이징
  - [x] 게시글 상세 페이지에 comment 폼 적용
  - [x] 댓글 등록 시 마지막 페이지 및 해당 댓글로 이동 구현
  - [x] 1페이지에 댓글 9개만 나오는 버그 수정
  - [x] detail 페이지 logout시 보이지 않던 오류 수정
- **note** :
  - 댓글 종료, Group에서는 fragment 참고해서 넣으시면 될겁니다! 안되시면 말씀주세영~
  - 유진님 게시글 삭제 부분에 관리자여도 보이게 했으니 컨트롤러나 서비스에서 admin일때도 가능하게 해주시면 관리자 권한 부여 될겁니당~

### ✅ **next plan**
- 알림 클릭 시 해당 댓글로 리다이렉트
- 신고 시 이벤트 발생(알림 생성 - "누군가 당신을 신고하였습니다. 누적 횟수 3회가 되면 3일간 로그인이 제한되니 주의해주세요(현재 1회)") 

Close #80 