### PR TITLE
fix : 대댓글 2개일때, 대댓글 삭제 시 부모 댓ë글도 함께 삭제되는 버그 수정

### DIFF
--- a/src/main/java/site/soloforest/soloforest/base/initData/NotProd.java
+++ b/src/main/java/site/soloforest/soloforest/base/initData/NotProd.java
@@ -108,8 +108,8 @@ public class NotProd {
 					community1, comment3);
 				Comment replyComment3 = commentService.createReplyComment("가시죠!!", false, accounts.get(1),
 					program1, comment8);
-				Comment replyComment4 = commentService.createReplyComment("가자구!", false, accounts.get(1),
-					program1, comment3);
+				Comment replyComment4 = commentService.createReplyComment("신고하세요22", false, accountAdmin1, community1,
+					comment3);
 
 				Comment comment17 = commentService.create("부모 댓글 연쇄 삭제 테스트용", false, accountAdmin1, community1);
 				comment17.deleteParent();

--- a/src/main/java/site/soloforest/soloforest/boundedContext/comment/service/CommentService.java
+++ b/src/main/java/site/soloforest/soloforest/boundedContext/comment/service/CommentService.java
@@ -114,6 +114,16 @@ public class CommentService {
 			return getDeletableAncestorComment(parent);
 		}
 
+		// Ajax 비동기 -> 대댓글이 2개일때 -> 컨트롤러에서 remove를 하고 서비스로 넘어오면, 사이즈가 또 1이되서 위에 if문의 조건을 만족
+		// 그러면 부모 댓글을 삭제해도 된다 생각하고 위의 if문에서 부모 댓글을 반환해 부모 댓글을 지운다.
+		// 그렇게 되면 실제 자식 객체는 고아객체가 되어 사라진다.
+		// 그걸 방지하고자 사이즈가 2라면 컨틀롤러에서 자식 지우고 오지 않고, 이 메서드에서 연관관계만 끊고 삭제하라 명령한다.
+		if (parent != null && parent.getChildren().size() == 2 && parent.isDeleted() == true) {
+			parent.getChildren().remove(comment);
+
+			return comment;
+		}
+
 		return comment;
 	}
 


### PR DESCRIPTION
### ✅ **Summary**

- **complete** : 부모 댓글이 삭제 상태일 때, 대댓글 2개일 때 삭제하면 댓글 자체가 삭제되는 버그를 수정하였습니다.
- **note** :

### ✅ **next plan**